### PR TITLE
更新処理で滅亡国と無政府国の操作を待機しない判定を追加

### DIFF
--- a/server/src/api/handlers/auth_handler.rs
+++ b/server/src/api/handlers/auth_handler.rs
@@ -139,6 +139,10 @@ mod tests {
     }
 
     impl UserRepository for InMemoryUserRepository {
+        fn find_by_uuid(&self, user_uuid: uuid::Uuid) -> Result<Option<UserRecord>, RepositoryError> {
+            Ok(self.state.borrow().rows.values().find(|row| row.uuid == user_uuid).cloned())
+        }
+
         fn find_by_discord_user_id(&self, discord_user_id: &str) -> Result<Option<UserRecord>, RepositoryError> {
             Ok(self.state.borrow().rows.get(discord_user_id).cloned())
         }

--- a/server/src/api/handlers/game_handler.rs
+++ b/server/src/api/handlers/game_handler.rs
@@ -185,6 +185,15 @@ mod tests {
     }
 
     impl UserRepository for InMemoryUserRepository {
+        fn find_by_uuid(&self, user_uuid: uuid::Uuid) -> Result<Option<UserRecord>, RepositoryError> {
+            Ok(self
+                .rows_by_token
+                .borrow()
+                .values()
+                .find(|row| row.uuid == user_uuid)
+                .cloned())
+        }
+
         fn find_by_discord_user_id(&self, _discord_user_id: &str) -> Result<Option<UserRecord>, RepositoryError> {
             Ok(None)
         }

--- a/server/src/api/middleware.rs
+++ b/server/src/api/middleware.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use super::GameProgressionError;
 use super::GameProgressionService;
 use super::GameRepository;
+use super::UserRepository;
 
 // ============================================================================
 // definitions
@@ -17,21 +18,23 @@ use super::GameRepository;
 ///
 /// リクエストハンドラ呼び出し前に [`GlobalPreHandler::run`] を実行することで、
 /// 卓の更新チェックや進行処理などの定期処理が自動的に実行される。
-pub(crate) struct GlobalPreHandler<G>
+pub(crate) struct GlobalPreHandler<U, G>
 where
+    U: UserRepository,
     G: GameRepository,
 {
-    progression_service: GameProgressionService<G>,
+    progression_service: GameProgressionService<U, G>,
 }
 
 /// グローバルプリハンドラの構造体の実装
-impl<G> GlobalPreHandler<G>
+impl<U, G> GlobalPreHandler<U, G>
 where
+    U: UserRepository,
     G: GameRepository,
 {
-    pub(crate) fn new(game_repository: G) -> Self {
+    pub(crate) fn new(user_repository: U, game_repository: G) -> Self {
         Self {
-            progression_service: GameProgressionService::new(game_repository),
+            progression_service: GameProgressionService::new(user_repository, game_repository),
         }
     }
 

--- a/server/src/api/router.rs
+++ b/server/src/api/router.rs
@@ -57,7 +57,7 @@ where
     pub user_repository: Arc<U>,
     pub game_service: Arc<GameService<U, G>>,
     pub auth_service: Arc<AuthService<U, D>>,
-    pub pre_handler: Arc<GlobalPreHandler<G>>,
+    pub pre_handler: Arc<GlobalPreHandler<U, G>>,
     pub game_update_lock: Arc<TokioMutex<()>>,
 }
 
@@ -72,7 +72,7 @@ where
         user_repository: U,
         game_service: GameService<U, G>,
         auth_service: AuthService<U, D>,
-        pre_handler: GlobalPreHandler<G>,
+        pre_handler: GlobalPreHandler<U, G>,
     ) -> Self {
         Self {
             user_repository: Arc::new(user_repository),
@@ -117,7 +117,7 @@ pub async fn serve(addr: SocketAddr, db_path: &str) -> Result<(), Box<dyn Error 
     let game_repository = SqliteGameRepository::new(db_path)?;
     let game_service = GameService::new(user_repository.clone(), game_repository.clone());
     let auth_service = AuthService::new(user_repository.clone(), DiscordApiClient::new());
-    let pre_handler = GlobalPreHandler::new(game_repository);
+    let pre_handler = GlobalPreHandler::new(user_repository.clone(), game_repository);
     let state = AppState::new(user_repository.clone(), game_service, auth_service, pre_handler);
     let router = create_router(state);
 
@@ -275,6 +275,15 @@ mod tests {
     }
 
     impl UserRepository for InMemoryUserRepository {
+        fn find_by_uuid(&self, user_uuid: uuid::Uuid) -> Result<Option<UserRecord>, super::super::RepositoryError> {
+            Ok(self
+                .user
+                .lock()
+                .expect("lock should succeed")
+                .clone()
+                .filter(|row| row.uuid == user_uuid))
+        }
+
         fn find_by_discord_user_id(&self, _discord_user_id: &str) -> Result<Option<UserRecord>, super::super::RepositoryError> {
             Ok(self.user.lock().expect("lock should succeed").clone())
         }

--- a/server/src/domain/models/regulation.rs
+++ b/server/src/domain/models/regulation.rs
@@ -2,8 +2,10 @@
 // imports
 // ============================================================================
 
+use chrono::FixedOffset;
 use chrono::NaiveDate;
 use chrono::NaiveDateTime;
+use chrono::TimeZone;
 use chrono::Timelike;
 use std::fmt;
 
@@ -67,13 +69,24 @@ impl Regulation {
     }
 
     fn next_day_at_first_period_hour(previous_next_update: NaiveDateTime, first_period_hour: u8) -> NaiveDateTime {
-        let next_date = previous_next_update
-            .date()
+        let jst = FixedOffset::east_opt(9 * 60 * 60).expect("JST offset should be valid");
+        let previous_jst =
+            chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(previous_next_update, chrono::Utc).with_timezone(&jst);
+
+        let next_date = previous_jst
+            .date_naive()
             .succ_opt()
             .expect("next day should exist for NaiveDate");
-        next_date
-            .and_hms_opt(u32::from(first_period_hour), 0, 0)
-            .expect("first_period_hour is validated in Regulation::new")
+
+        jst.from_local_datetime(
+            &next_date
+                .and_hms_opt(u32::from(first_period_hour), 0, 0)
+                .expect("first_period_hour is validated in Regulation::new"),
+        )
+        .single()
+        .expect("JST local datetime should map uniquely")
+        .with_timezone(&chrono::Utc)
+        .naive_utc()
     }
 
     fn is_sub_phase(phase: &super::Phase) -> bool {
@@ -343,7 +356,7 @@ mod tests {
             next_update,
             NaiveDate::from_ymd_opt(2026, 4, 23)
                 .expect("valid date")
-                .and_hms_opt(21, 0, 0)
+                .and_hms_opt(12, 0, 0)
                 .expect("valid datetime")
         );
     }

--- a/server/src/repositories/sqlite_game_repository.rs
+++ b/server/src/repositories/sqlite_game_repository.rs
@@ -401,6 +401,18 @@ impl SqliteGameRepository {
             .unwrap_or_else(|_| text.split(',').map(|value| value.to_string()).collect::<Vec<_>>())
     }
 
+    fn serialize_next_update(next_update: NaiveDateTime) -> String {
+        chrono::DateTime::<Utc>::from_naive_utc_and_offset(next_update, Utc).to_rfc3339()
+    }
+
+    fn parse_next_update(text: &str) -> Result<NaiveDateTime, RepositoryError> {
+        chrono::DateTime::parse_from_rfc3339(text)
+            .map(|dt| dt.with_timezone(&Utc).naive_utc())
+            .or_else(|_| NaiveDateTime::parse_from_str(text, "%Y-%m-%d %H:%M:%S%.f"))
+            .or_else(|_| NaiveDateTime::parse_from_str(text, "%Y-%m-%d %H:%M:%S"))
+            .map_err(|error| RepositoryError::Unavailable(format!("parse next_update: {}", error)))
+    }
+
     fn load_games_by_query<P>(connection: &Connection, sql: &str, params: P) -> Result<Vec<Game>, RepositoryError>
     where
         P: rusqlite::Params,
@@ -583,15 +595,7 @@ impl SqliteGameRepository {
                 phases.push(phase);
             }
 
-            let next_update = row
-                .next_update
-                .as_deref()
-                .map(|s| {
-                    NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f")
-                        .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S"))
-                        .map_err(|error| RepositoryError::Unavailable(format!("parse next_update: {}", error)))
-                })
-                .transpose()?;
+            let next_update = row.next_update.as_deref().map(Self::parse_next_update).transpose()?;
 
             games.push(Game {
                 uuid,
@@ -708,7 +712,7 @@ impl GameRepository for SqliteGameRepository {
                     game.is_canceled as i32,
                     game.is_draw as i32,
                     game.is_solo as i32,
-                    game.next_update_at.map(|dt| dt.to_string()),
+                    game.next_update_at.map(Self::serialize_next_update),
                     now,
                     now,
                 ],
@@ -834,14 +838,14 @@ impl GameRepository for SqliteGameRepository {
                 FROM games
                 WHERE status != 'closed'
                   AND next_update IS NOT NULL
-                  AND next_update <= ?1
-                ORDER BY next_update ASC, uuid ASC
+                                    AND julianday(next_update) <= julianday(?1)
+                                ORDER BY julianday(next_update) ASC, uuid ASC
                 "#,
             )
             .map_err(|error| RepositoryError::Unavailable(format!("prepare find_progress_candidates: {}", error)))?;
 
         let uuid_rows = stmt
-            .query_map(params![now.to_string()], |row| row.get::<_, String>(0))
+            .query_map(params![Self::serialize_next_update(now)], |row| row.get::<_, String>(0))
             .map_err(|error| RepositoryError::Unavailable(format!("query find_progress_candidates: {}", error)))?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|error| RepositoryError::Unavailable(format!("collect find_progress_candidates: {}", error)))?;
@@ -885,7 +889,7 @@ impl GameRepository for SqliteGameRepository {
                     game.is_canceled as i32,
                     game.is_draw as i32,
                     game.is_solo as i32,
-                    game.next_update_at.map(|dt| dt.to_string()),
+                    game.next_update_at.map(Self::serialize_next_update),
                     now,
                 ],
             )

--- a/server/src/repositories/sqlite_game_repository.rs
+++ b/server/src/repositories/sqlite_game_repository.rs
@@ -408,8 +408,6 @@ impl SqliteGameRepository {
     fn parse_next_update(text: &str) -> Result<NaiveDateTime, RepositoryError> {
         chrono::DateTime::parse_from_rfc3339(text)
             .map(|dt| dt.with_timezone(&Utc).naive_utc())
-            .or_else(|_| NaiveDateTime::parse_from_str(text, "%Y-%m-%d %H:%M:%S%.f"))
-            .or_else(|_| NaiveDateTime::parse_from_str(text, "%Y-%m-%d %H:%M:%S"))
             .map_err(|error| RepositoryError::Unavailable(format!("parse next_update: {}", error)))
     }
 

--- a/server/src/repositories/sqlite_user_repository.rs
+++ b/server/src/repositories/sqlite_user_repository.rs
@@ -122,6 +122,21 @@ impl SqliteUserRepository {
 
 /// SQLite 用のユーザリポジトリ構造体の実装（UserRepository トレイト）
 impl UserRepository for SqliteUserRepository {
+    fn find_by_uuid(&self, user_uuid: uuid::Uuid) -> Result<Option<UserRecord>, RepositoryError> {
+        let sql = r#"
+            SELECT id, uuid, discord_user_id, username, global_name, avatar_hash, avatar_url, access_token, last_access_at
+            FROM users
+            WHERE uuid = ?1
+        "#;
+
+        self.connection
+            .lock()
+            .map_err(|error| RepositoryError::Unavailable(format!("lock sqlite connection: {}", error)))?
+            .query_row(sql, params![user_uuid.to_string()], Self::row_to_user_record)
+            .optional()
+            .map_err(|error| RepositoryError::Unavailable(format!("find user by uuid: {}", error)))
+    }
+
     fn find_by_discord_user_id(&self, discord_user_id: &str) -> Result<Option<UserRecord>, RepositoryError> {
         let sql = r#"
             SELECT id, uuid, discord_user_id, username, global_name, avatar_hash, avatar_url, access_token, last_access_at

--- a/server/src/repositories/user_repository.rs
+++ b/server/src/repositories/user_repository.rs
@@ -82,6 +82,8 @@ impl From<&DiscordProfile> for UserProfileUpdate {
 /// ユーザリポジトリのトレイト
 ///
 pub(crate) trait UserRepository {
+    fn find_by_uuid(&self, user_uuid: Uuid) -> Result<Option<UserRecord>, RepositoryError>;
+
     fn find_by_discord_user_id(&self, discord_user_id: &str) -> Result<Option<UserRecord>, RepositoryError>;
 
     fn find_by_access_token(&self, access_token: &str) -> Result<Option<UserRecord>, RepositoryError>;

--- a/server/src/services/auth_service.rs
+++ b/server/src/services/auth_service.rs
@@ -185,6 +185,10 @@ mod tests {
     }
 
     impl UserRepository for InMemoryUserRepository {
+        fn find_by_uuid(&self, user_uuid: Uuid) -> Result<Option<UserRecord>, RepositoryError> {
+            Ok(self.state.borrow().rows.values().find(|row| row.uuid == user_uuid).cloned())
+        }
+
         fn find_by_discord_user_id(&self, discord_user_id: &str) -> Result<Option<UserRecord>, RepositoryError> {
             Ok(self.state.borrow().rows.get(discord_user_id).cloned())
         }

--- a/server/src/services/game_progression_service.rs
+++ b/server/src/services/game_progression_service.rs
@@ -398,7 +398,7 @@ mod tests {
                 past_date
                     .succ_opt()
                     .expect("next day should exist")
-                    .and_hms_opt(21, 0, 0)
+                    .and_hms_opt(12, 0, 0)
                     .expect("valid datetime")
             )
         );

--- a/server/src/services/game_progression_service.rs
+++ b/server/src/services/game_progression_service.rs
@@ -2,12 +2,12 @@
 // imports
 // ============================================================================
 
-use chrono::Utc;
-
 use super::GameProgressionError;
 use super::GameRepository;
 use super::GameStatus;
 use super::PhaseContext;
+use super::UserRepository;
+use chrono::Utc;
 
 // ============================================================================
 // definitions
@@ -16,20 +16,26 @@ use super::PhaseContext;
 ///
 /// 卓進行サービスの構造体
 ///
-pub(crate) struct GameProgressionService<G>
+pub(crate) struct GameProgressionService<U, G>
 where
+    U: UserRepository,
     G: GameRepository,
 {
+    user_repository: U,
     game_repository: G,
 }
 
 /// 卓進行サービスの構造体の実装
-impl<G> GameProgressionService<G>
+impl<U, G> GameProgressionService<U, G>
 where
+    U: UserRepository,
     G: GameRepository,
 {
-    pub(crate) fn new(game_repository: G) -> Self {
-        Self { game_repository }
+    pub(crate) fn new(user_repository: U, game_repository: G) -> Self {
+        Self {
+            user_repository,
+            game_repository,
+        }
     }
 
     /// Closed 以外の全 Game に対してフェイズ進行を試みる。
@@ -69,6 +75,7 @@ where
         let latest_phase = game.phases.pop().expect("game should have at least one phase");
 
         let mut context = PhaseContext::new();
+        self.remove_idle_powers(&game, &mut context, now)?;
         latest_phase.close(&mut context);
 
         let is_finished = context.is_finished();
@@ -96,6 +103,36 @@ where
 
         Ok(())
     }
+
+    fn remove_idle_powers(
+        &self,
+        game: &super::Game,
+        context: &mut PhaseContext,
+        now: chrono::NaiveDateTime,
+    ) -> Result<(), GameProgressionError> {
+        let idle_limit = chrono::Duration::minutes(i64::from(game.regulation.duration_type.idle_limit_minutes()));
+        let threshold = now - idle_limit;
+
+        for player in game.players.iter().filter(|player| player.power.is_some()) {
+            let power = player.power.expect("filtered as Some");
+
+            let user = self
+                .user_repository
+                .find_by_uuid(player.user_uuid)
+                .map_err(GameProgressionError::Repository)?;
+
+            let is_idle_or_missing = match user {
+                Some(user) => user.last_access_at.naive_utc() <= threshold,
+                None => true,
+            };
+
+            if is_idle_or_missing {
+                context.remove_power(&power);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // ============================================================================
@@ -105,6 +142,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;
+    use std::collections::HashMap;
     use std::rc::Rc;
 
     use super::*;
@@ -117,7 +155,11 @@ mod tests {
     use crate::domain::ProgressMode;
     use crate::domain::Regulation;
     use crate::repositories::NewGame;
+    use crate::repositories::NewUser;
     use crate::repositories::RepositoryError;
+    use crate::repositories::UserId;
+    use crate::repositories::UserProfileUpdate;
+    use crate::repositories::UserRecord;
 
     #[derive(Debug, Clone)]
     struct InMemoryGameRepository {
@@ -172,6 +214,61 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone)]
+    struct InMemoryUserRepository {
+        rows_by_uuid: Rc<RefCell<HashMap<uuid::Uuid, UserRecord>>>,
+    }
+
+    impl InMemoryUserRepository {
+        fn new(rows: Vec<UserRecord>) -> Self {
+            let map = rows.into_iter().map(|row| (row.uuid, row)).collect();
+            Self {
+                rows_by_uuid: Rc::new(RefCell::new(map)),
+            }
+        }
+    }
+
+    impl UserRepository for InMemoryUserRepository {
+        fn find_by_uuid(&self, user_uuid: uuid::Uuid) -> Result<Option<UserRecord>, RepositoryError> {
+            Ok(self.rows_by_uuid.borrow().get(&user_uuid).cloned())
+        }
+
+        fn find_by_discord_user_id(&self, _discord_user_id: &str) -> Result<Option<UserRecord>, RepositoryError> {
+            Ok(None)
+        }
+
+        fn find_by_access_token(&self, access_token: &str) -> Result<Option<UserRecord>, RepositoryError> {
+            Ok(self
+                .rows_by_uuid
+                .borrow()
+                .values()
+                .find(|row| row.access_token == access_token)
+                .cloned())
+        }
+
+        fn update_last_access_at_by_access_token(
+            &self,
+            access_token: &str,
+            last_access_at: chrono::DateTime<chrono::Utc>,
+        ) -> Result<bool, RepositoryError> {
+            let mut rows = self.rows_by_uuid.borrow_mut();
+            let Some(row) = rows.values_mut().find(|row| row.access_token == access_token) else {
+                return Ok(false);
+            };
+
+            row.last_access_at = last_access_at;
+            Ok(true)
+        }
+
+        fn insert(&self, _new_user: NewUser) -> Result<UserRecord, RepositoryError> {
+            Err(RepositoryError::Unavailable("not used".to_string()))
+        }
+
+        fn update_profile(&self, _id: UserId, _profile: UserProfileUpdate) -> Result<UserRecord, RepositoryError> {
+            Err(RepositoryError::Unavailable("not used".to_string()))
+        }
+    }
+
     fn sample_regulation() -> Regulation {
         Regulation::new(
             FaceType::Girls,
@@ -188,12 +285,13 @@ mod tests {
     }
 
     fn sample_game_with_regulation(next_update: Option<chrono::NaiveDateTime>, regulation: Regulation) -> Game {
+        let owner_uuid = uuid::Uuid::now_v7();
         Game {
             uuid: uuid::Uuid::now_v7(),
             game_number: None,
             regulation,
             players: vec![Player {
-                user_uuid: uuid::Uuid::now_v7(),
+                user_uuid: owner_uuid,
                 power: Some(Power::France),
                 is_accepting_draw: false,
                 is_owner: true,
@@ -208,10 +306,33 @@ mod tests {
         }
     }
 
+    fn user_for(game: &Game, power: Power, last_access_at: chrono::DateTime<chrono::Utc>) -> UserRecord {
+        let user_uuid = game
+            .players
+            .iter()
+            .find(|player| player.power == Some(power))
+            .map(|player| player.user_uuid)
+            .expect("player for power should exist");
+
+        UserRecord {
+            id: 1,
+            uuid: user_uuid,
+            discord_user_id: format!("discord-{}", power.symbol()),
+            username: format!("{}-user", power.symbol()),
+            global_name: None,
+            avatar_hash: None,
+            avatar_url: None,
+            access_token: format!("token-{}", power.symbol()),
+            last_access_at,
+        }
+    }
+
     #[test]
     fn progress_games_skips_when_next_update_is_none() {
-        let repository = InMemoryGameRepository::new(vec![sample_game(None)]);
-        let service = GameProgressionService::new(repository.clone());
+        let game = sample_game(None);
+        let users = InMemoryUserRepository::new(vec![user_for(&game, Power::France, chrono::Utc::now())]);
+        let repository = InMemoryGameRepository::new(vec![game]);
+        let service = GameProgressionService::new(users, repository.clone());
 
         service.progress_games().expect("progress should succeed");
 
@@ -221,8 +342,10 @@ mod tests {
     #[test]
     fn progress_games_skips_when_next_update_is_in_future() {
         let future = chrono::Utc::now().naive_utc() + chrono::Duration::minutes(5);
-        let repository = InMemoryGameRepository::new(vec![sample_game(Some(future))]);
-        let service = GameProgressionService::new(repository.clone());
+        let game = sample_game(Some(future));
+        let users = InMemoryUserRepository::new(vec![user_for(&game, Power::France, chrono::Utc::now())]);
+        let repository = InMemoryGameRepository::new(vec![game]);
+        let service = GameProgressionService::new(users, repository.clone());
 
         service.progress_games().expect("progress should succeed");
 
@@ -233,8 +356,10 @@ mod tests {
     fn progress_games_updates_when_next_update_is_in_past() {
         let past_date = (chrono::Utc::now().naive_utc() - chrono::Duration::days(1)).date();
         let past = past_date.and_hms_opt(14, 32, 0).expect("valid datetime");
-        let repository = InMemoryGameRepository::new(vec![sample_game(Some(past))]);
-        let service = GameProgressionService::new(repository.clone());
+        let game = sample_game(Some(past));
+        let users = InMemoryUserRepository::new(vec![user_for(&game, Power::France, chrono::Utc::now())]);
+        let repository = InMemoryGameRepository::new(vec![game]);
+        let service = GameProgressionService::new(users, repository.clone());
 
         service.progress_games().expect("progress should succeed");
 
@@ -259,8 +384,10 @@ mod tests {
         .expect("valid regulation");
         let past_date = (chrono::Utc::now().naive_utc() - chrono::Duration::days(1)).date();
         let past = past_date.and_hms_opt(14, 32, 0).expect("valid datetime");
-        let repository = InMemoryGameRepository::new(vec![sample_game_with_regulation(Some(past), regulation)]);
-        let service = GameProgressionService::new(repository.clone());
+        let game = sample_game_with_regulation(Some(past), regulation);
+        let users = InMemoryUserRepository::new(vec![user_for(&game, Power::France, chrono::Utc::now())]);
+        let repository = InMemoryGameRepository::new(vec![game]);
+        let service = GameProgressionService::new(users, repository.clone());
 
         service.progress_games().expect("progress should succeed");
 
@@ -275,5 +402,78 @@ mod tests {
                     .expect("valid datetime")
             )
         );
+    }
+
+    #[test]
+    fn progress_games_skips_retreat_wait_for_idle_power() {
+        let past_date = (chrono::Utc::now().naive_utc() - chrono::Duration::days(1)).date();
+        let past = past_date.and_hms_opt(14, 32, 0).expect("valid datetime");
+
+        let mut game = sample_game(Some(past));
+        let france_user_uuid = uuid::Uuid::now_v7();
+        let germany_user_uuid = uuid::Uuid::now_v7();
+        game.players = vec![
+            Player {
+                user_uuid: france_user_uuid,
+                power: Some(Power::France),
+                is_accepting_draw: false,
+                is_owner: true,
+                requested_power: Some(Power::France),
+            },
+            Player {
+                user_uuid: germany_user_uuid,
+                power: Some(Power::Germany),
+                is_accepting_draw: false,
+                is_owner: false,
+                requested_power: Some(Power::Germany),
+            },
+        ];
+        let mut spring_main = Phase::new_spring_main(1900, 0);
+        spring_main.units = vec![
+            crate::domain::Unit::new_army(
+                Power::Germany,
+                crate::domain::Province::from_code("ber").expect("valid province"),
+            )
+            .set_dislodged_from(Some(crate::domain::Province::from_code("kie").expect("valid province"))),
+        ];
+        spring_main.territories = vec![crate::domain::Territory::new(Power::Germany, "ber")];
+        game.phases = vec![spring_main];
+        game.status = GameStatus::InProgress;
+
+        let users = InMemoryUserRepository::new(vec![
+            UserRecord {
+                id: 1,
+                uuid: france_user_uuid,
+                discord_user_id: "discord-f".to_string(),
+                username: "f-user".to_string(),
+                global_name: None,
+                avatar_hash: None,
+                avatar_url: None,
+                access_token: "token-f".to_string(),
+                last_access_at: chrono::Utc::now(),
+            },
+            UserRecord {
+                id: 2,
+                uuid: germany_user_uuid,
+                discord_user_id: "discord-g".to_string(),
+                username: "g-user".to_string(),
+                global_name: None,
+                avatar_hash: None,
+                avatar_url: None,
+                access_token: "token-g".to_string(),
+                last_access_at: chrono::Utc::now()
+                    - chrono::Duration::minutes(i64::from(game.regulation.duration_type.idle_limit_minutes() + 1)),
+            },
+        ]);
+        let repository = InMemoryGameRepository::new(vec![game]);
+        let service = GameProgressionService::new(users, repository.clone());
+
+        service.progress_games().expect("progress should succeed");
+
+        let updated = repository.updated_first().expect("updated game should exist");
+        assert!(matches!(
+            updated.phases.last().expect("phase should exist").kind,
+            crate::domain::PhaseKind::FallMain(_)
+        ));
     }
 }

--- a/server/src/services/game_service.rs
+++ b/server/src/services/game_service.rs
@@ -168,6 +168,10 @@ mod tests {
     }
 
     impl UserRepository for InMemoryUserRepository {
+        fn find_by_uuid(&self, user_uuid: Uuid) -> Result<Option<UserRecord>, RepositoryError> {
+            Ok(self.rows.borrow().values().find(|row| row.uuid == user_uuid).cloned())
+        }
+
         fn find_by_discord_user_id(&self, _discord_user_id: &str) -> Result<Option<UserRecord>, RepositoryError> {
             Ok(None)
         }

--- a/server/src/services/game_service.rs
+++ b/server/src/services/game_service.rs
@@ -2,6 +2,8 @@
 // imports
 // ============================================================================
 
+use chrono::FixedOffset;
+use chrono::TimeZone;
 use uuid::Uuid;
 
 use super::CreateGameError;
@@ -84,13 +86,24 @@ where
             requested_power: command.requested_power,
         };
 
-        let next_update = command
+        let next_update_jst = command
             .regulation
             .start_date
             .and_hms_opt(command.regulation.first_period_hour as u32, 0, 0)
             .ok_or(CreateGameError::InvalidRequest(
                 "first_period_hour is out of range".to_string(),
             ))?;
+
+        let jst = FixedOffset::east_opt(9 * 60 * 60)
+            .ok_or(CreateGameError::Internal("failed to build JST timezone offset".to_string()))?;
+        let next_update = jst
+            .from_local_datetime(&next_update_jst)
+            .single()
+            .ok_or(CreateGameError::Internal(
+                "failed to convert next_update from JST local time".to_string(),
+            ))?
+            .with_timezone(&chrono::Utc)
+            .naive_utc();
 
         let game = Game {
             uuid: Uuid::now_v7(),
@@ -284,5 +297,41 @@ mod tests {
         assert!(owner.is_owner);
         assert_eq!(owner.requested_power, Some(Power::France));
         assert_eq!(result.game.phases.len(), 1);
+    }
+
+    #[test]
+    fn create_game_converts_initial_next_update_from_jst_to_utc() {
+        let user_uuid = Uuid::now_v7();
+        let user_repository = InMemoryUserRepository::new(vec![UserRecord {
+            id: 1,
+            uuid: user_uuid,
+            discord_user_id: "1001".to_string(),
+            username: "asagi".to_string(),
+            global_name: None,
+            avatar_hash: None,
+            avatar_url: None,
+            access_token: "token-1".to_string(),
+            last_access_at: Utc::now(),
+        }]);
+        let game_repository = InMemoryGameRepository::new();
+        let service = GameService::new(user_repository, game_repository);
+
+        let result = service
+            .create_game(CreateGameCommand {
+                access_token: "token-1".to_string(),
+                regulation: sample_regulation(),
+                requested_power: None,
+            })
+            .expect("create game should succeed");
+
+        assert_eq!(
+            result.game.next_update_at,
+            Some(
+                chrono::NaiveDate::from_ymd_opt(2026, 4, 19)
+                    .expect("valid date")
+                    .and_hms_opt(3, 0, 0)
+                    .expect("valid datetime")
+            )
+        );
     }
 }

--- a/server/src/services/game_service.rs
+++ b/server/src/services/game_service.rs
@@ -96,6 +96,7 @@ where
 
         let jst = FixedOffset::east_opt(9 * 60 * 60)
             .ok_or(CreateGameError::Internal("failed to build JST timezone offset".to_string()))?;
+        // API request start_date/first_period_hour are JST business-time inputs.
         let next_update = jst
             .from_local_datetime(&next_update_jst)
             .single()


### PR DESCRIPTION
### Time handling note (JST input, UTC storage)

このPRには、更新待機判定の改善に加えて、`next_update_at` の時刻取り扱いを明確化する変更が含まれます。

- API入力の `start_date` / `first_period_hour` は **JSTローカル時刻の業務意味**として解釈する
- 内部処理および DB（`games.next_update`）は **UTC（RFC3339）** で保持する
- 新卓作成時の初回 `next_update_at` は JST から UTC へ変換して保存する
- Scheduled + Normal のメインフェイズで算出する翌日更新時刻も、JST基準の `first_period_hour` を UTC に変換して保存する
- `next_update` のパースは RFC3339 前提（後方互換形式は扱わない）

前提:
- まだ本番稼働前であり、既存データ移行は不要（DBは空である前提）

Closes #70 #74 

