### PR TITLE
募集不成立卓の処理の実装

### DIFF
--- a/server/src/domain/models/game.rs
+++ b/server/src/domain/models/game.rs
@@ -32,7 +32,6 @@ pub(crate) struct Game {
     pub(crate) players: Vec<Player>,
     pub(crate) phases: Vec<Phase>,
     pub(crate) status: GameStatus,
-    pub(crate) is_canceled: bool,
     pub(crate) is_draw: bool,
     pub(crate) is_solo: bool,
     pub(crate) next_update_at: Option<NaiveDateTime>,
@@ -124,6 +123,7 @@ pub(crate) enum GameStatus {
     Ready,
     InProgress,
     Finished,
+    Aborted,
     Closed,
 }
 
@@ -151,7 +151,6 @@ mod tests {
             }],
             phases: vec![Phase::new_ready()],
             status: GameStatus::Preparing,
-            is_canceled: false,
             is_draw: false,
             is_solo: false,
             next_update_at: None,

--- a/server/src/repositories/sqlite_game_repository.rs
+++ b/server/src/repositories/sqlite_game_repository.rs
@@ -1469,4 +1469,87 @@ mod transaction_tests {
 
         assert_eq!(game_count, 0, "game row should be rolled back on failure");
     }
+
+    #[test]
+    fn find_all_active_excludes_aborted_games() {
+        let repository = SqliteGameRepository::new_in_memory().expect("repository should initialize");
+
+        let regulation = Regulation::new(
+            FaceType::Girls,
+            ProgressMode::Scheduled,
+            DurationType::Short,
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 19).expect("valid date"),
+            12,
+        )
+        .expect("valid regulation");
+
+        let game = Game {
+            uuid: uuid::Uuid::now_v7(),
+            game_number: None,
+            regulation,
+            players: vec![Player {
+                user_uuid: uuid::Uuid::now_v7(),
+                power: Some(Power::France),
+                is_accepting_draw: false,
+                is_owner: true,
+                requested_power: Some(Power::France),
+            }],
+            phases: vec![Phase::new_ready()],
+            status: GameStatus::Aborted,
+            is_draw: false,
+            is_solo: false,
+            next_update_at: None,
+        };
+
+        repository.insert(NewGame { game }).expect("insert should succeed");
+
+        let active_games = repository.find_all_active().expect("find_all_active should succeed");
+        assert!(active_games.is_empty(), "aborted game should not appear in find_all_active");
+    }
+
+    #[test]
+    fn find_progress_candidates_excludes_aborted_games() {
+        let repository = SqliteGameRepository::new_in_memory().expect("repository should initialize");
+
+        let regulation = Regulation::new(
+            FaceType::Girls,
+            ProgressMode::Scheduled,
+            DurationType::Short,
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 19).expect("valid date"),
+            12,
+        )
+        .expect("valid regulation");
+
+        let past = chrono::NaiveDate::from_ymd_opt(2026, 4, 18)
+            .expect("valid date")
+            .and_hms_opt(9, 0, 0)
+            .expect("valid datetime");
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 4, 19)
+            .expect("valid date")
+            .and_hms_opt(9, 0, 0)
+            .expect("valid datetime");
+
+        let game = Game {
+            uuid: uuid::Uuid::now_v7(),
+            game_number: None,
+            regulation,
+            players: vec![Player {
+                user_uuid: uuid::Uuid::now_v7(),
+                power: Some(Power::France),
+                is_accepting_draw: false,
+                is_owner: true,
+                requested_power: Some(Power::France),
+            }],
+            phases: vec![Phase::new_ready()],
+            status: GameStatus::Aborted,
+            is_draw: false,
+            is_solo: false,
+            next_update_at: Some(past),
+        };
+
+        repository.insert(NewGame { game }).expect("insert should succeed");
+
+        let candidates = repository.find_progress_candidates(now).expect("find_progress_candidates should succeed");
+        assert!(candidates.is_empty(), "aborted game should not appear in find_progress_candidates");
+    }
 }

--- a/server/src/repositories/sqlite_game_repository.rs
+++ b/server/src/repositories/sqlite_game_repository.rs
@@ -84,7 +84,6 @@ impl SqliteGameRepository {
                 regulation_start_date TEXT NOT NULL,
                 regulation_first_period_hour INTEGER NOT NULL,
                 status TEXT NOT NULL DEFAULT 'preparing',
-                is_canceled INTEGER NOT NULL DEFAULT 0,
                 is_draw INTEGER NOT NULL DEFAULT 0,
                 is_solo INTEGER NOT NULL DEFAULT 0,
                 next_update TEXT,
@@ -140,6 +139,7 @@ impl SqliteGameRepository {
             GameStatus::Ready => "ready",
             GameStatus::InProgress => "in_progress",
             GameStatus::Finished => "finished",
+            GameStatus::Aborted => "aborted",
             GameStatus::Closed => "closed",
         }
     }
@@ -150,6 +150,7 @@ impl SqliteGameRepository {
             "ready" => Ok(GameStatus::Ready),
             "in_progress" => Ok(GameStatus::InProgress),
             "finished" => Ok(GameStatus::Finished),
+            "aborted" => Ok(GameStatus::Aborted),
             "closed" => Ok(GameStatus::Closed),
             _ => Err(RepositoryError::Unavailable(format!("unknown game status: {}", text))),
         }
@@ -424,7 +425,6 @@ impl SqliteGameRepository {
             start_date: String,
             first_period_hour: i32,
             status: String,
-            is_canceled: i32,
             is_draw: i32,
             is_solo: i32,
             next_update: Option<String>,
@@ -445,10 +445,9 @@ impl SqliteGameRepository {
                     start_date: row.get(5)?,
                     first_period_hour: row.get(6)?,
                     status: row.get(7)?,
-                    is_canceled: row.get(8)?,
-                    is_draw: row.get(9)?,
-                    is_solo: row.get(10)?,
-                    next_update: row.get(11)?,
+                    is_draw: row.get(8)?,
+                    is_solo: row.get(9)?,
+                    next_update: row.get(10)?,
                 })
             })
             .map_err(|error| RepositoryError::Unavailable(format!("query load games: {}", error)))?
@@ -602,7 +601,6 @@ impl SqliteGameRepository {
                 players,
                 phases,
                 status: Self::status_from_str(&row.status)?,
-                is_canceled: row.is_canceled != 0,
                 is_draw: row.is_draw != 0,
                 is_solo: row.is_solo != 0,
                 next_update_at: next_update,
@@ -690,13 +688,12 @@ impl GameRepository for SqliteGameRepository {
                     regulation_start_date,
                     regulation_first_period_hour,
                     status,
-                    is_canceled,
                     is_draw,
                     is_solo,
                     next_update,
                     created_at,
                     updated_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
                 "#,
                 params![
                     game.uuid.to_string(),
@@ -707,7 +704,6 @@ impl GameRepository for SqliteGameRepository {
                     game.regulation.start_date.to_string(),
                     game.regulation.first_period_hour as i32,
                     Self::serialize_status(game.status),
-                    game.is_canceled as i32,
                     game.is_draw as i32,
                     game.is_solo as i32,
                     game.next_update_at.map(Self::serialize_next_update),
@@ -794,9 +790,9 @@ impl GameRepository for SqliteGameRepository {
             r#"
             SELECT uuid, game_number, regulation_face_type, regulation_progress_mode,
                    regulation_duration_type, regulation_start_date, regulation_first_period_hour,
-                   status, is_canceled, is_draw, is_solo, next_update
+                   status, is_draw, is_solo, next_update
             FROM games
-            WHERE status != 'closed'
+            WHERE status NOT IN ('closed', 'aborted')
             "#,
             [],
         )
@@ -813,7 +809,7 @@ impl GameRepository for SqliteGameRepository {
             r#"
             SELECT uuid, game_number, regulation_face_type, regulation_progress_mode,
                    regulation_duration_type, regulation_start_date, regulation_first_period_hour,
-                   status, is_canceled, is_draw, is_solo, next_update
+                   status, is_draw, is_solo, next_update
             FROM games
             WHERE uuid = ?1
             "#,
@@ -834,7 +830,7 @@ impl GameRepository for SqliteGameRepository {
                 r#"
                 SELECT uuid
                 FROM games
-                WHERE status != 'closed'
+                WHERE status NOT IN ('closed', 'aborted')
                   AND next_update IS NOT NULL
                                     AND julianday(next_update) <= julianday(?1)
                                 ORDER BY julianday(next_update) ASC, uuid ASC
@@ -874,17 +870,15 @@ impl GameRepository for SqliteGameRepository {
                 r#"
                 UPDATE games
                 SET status = ?2,
-                    is_canceled = ?3,
-                    is_draw = ?4,
-                    is_solo = ?5,
-                    next_update = ?6,
-                    updated_at = ?7
+                    is_draw = ?3,
+                    is_solo = ?4,
+                    next_update = ?5,
+                    updated_at = ?6
                 WHERE uuid = ?1
                 "#,
                 params![
                     game.uuid.to_string(),
                     Self::serialize_status(game.status),
-                    game.is_canceled as i32,
                     game.is_draw as i32,
                     game.is_solo as i32,
                     game.next_update_at.map(Self::serialize_next_update),
@@ -1100,7 +1094,6 @@ mod tests {
             }],
             phases: vec![Phase::new_ready()],
             status: GameStatus::Preparing,
-            is_canceled: false,
             is_draw: false,
             is_solo: false,
             next_update_at: None,
@@ -1156,7 +1149,6 @@ mod tests {
             }],
             phases: vec![phase.clone()],
             status: GameStatus::Preparing,
-            is_canceled: false,
             is_draw: false,
             is_solo: false,
             next_update_at: None,
@@ -1277,7 +1269,6 @@ mod tests {
             }],
             phases: vec![Phase::new_ready()],
             status: GameStatus::InProgress,
-            is_canceled: true,
             is_draw: true,
             is_solo: false,
             next_update_at: Some(next_update),
@@ -1289,7 +1280,6 @@ mod tests {
         assert_eq!(active_games.len(), 1);
         let restored = &active_games[0];
         assert_eq!(restored.status, GameStatus::InProgress);
-        assert!(restored.is_canceled);
         assert!(restored.is_draw);
         assert!(!restored.is_solo);
         assert_eq!(restored.next_update_at, Some(next_update));
@@ -1324,7 +1314,6 @@ mod tests {
             }],
             phases: vec![initial_phase],
             status: GameStatus::Preparing,
-            is_canceled: false,
             is_draw: false,
             is_solo: false,
             next_update_at: None,
@@ -1389,7 +1378,6 @@ mod tests {
             }],
             phases: vec![Phase::new_ready()],
             status: GameStatus::InProgress,
-            is_canceled: false,
             is_draw: false,
             is_solo: false,
             next_update_at: None,
@@ -1460,7 +1448,6 @@ mod transaction_tests {
             }],
             phases: vec![Phase::new_ready()],
             status: GameStatus::Preparing,
-            is_canceled: false,
             is_draw: false,
             is_solo: false,
             next_update_at: None,

--- a/server/src/repositories/sqlite_game_repository.rs
+++ b/server/src/repositories/sqlite_game_repository.rs
@@ -1549,7 +1549,12 @@ mod transaction_tests {
 
         repository.insert(NewGame { game }).expect("insert should succeed");
 
-        let candidates = repository.find_progress_candidates(now).expect("find_progress_candidates should succeed");
-        assert!(candidates.is_empty(), "aborted game should not appear in find_progress_candidates");
+        let candidates = repository
+            .find_progress_candidates(now)
+            .expect("find_progress_candidates should succeed");
+        assert!(
+            candidates.is_empty(),
+            "aborted game should not appear in find_progress_candidates"
+        );
     }
 }

--- a/server/src/services/game_progression_service.rs
+++ b/server/src/services/game_progression_service.rs
@@ -8,6 +8,7 @@ use super::GameStatus;
 use super::PhaseContext;
 use super::UserRepository;
 use chrono::Utc;
+use strum::IntoEnumIterator;
 
 // ============================================================================
 // definitions
@@ -38,7 +39,7 @@ where
         }
     }
 
-    /// Closed 以外の全 Game に対してフェイズ進行を試みる。
+    /// Closed・Aborted 以外の全 Game に対してフェイズ進行を試みる。
     /// next_update_at が現在時刻より過去の場合のみ進行処理を実行する。
     pub(crate) fn progress_games(&self) -> Result<(), GameProgressionError> {
         let now = Utc::now().naive_utc();
@@ -77,7 +78,7 @@ where
         // 募集不成立チェック: Ready フェイズ到達時点でプレイヤーが 7 人未満なら中止
         if matches!(latest_phase.kind, crate::domain::PhaseKind::Ready(_))
             && game.status != GameStatus::InProgress
-            && game.players.iter().filter(|p| p.power.is_some()).count() < 7
+            && game.players.iter().filter(|p| p.power.is_some()).count() < crate::domain::Power::iter().count()
         {
             game.phases.push(latest_phase);
             game.status = GameStatus::Aborted;
@@ -300,7 +301,7 @@ mod tests {
                 .active_games
                 .borrow()
                 .iter()
-                .filter(|game| game.status != GameStatus::Closed)
+                .filter(|game| game.status != GameStatus::Closed && game.status != GameStatus::Aborted)
                 .filter(|game| game.next_update_at.is_some_and(|next_update| next_update <= now))
                 .map(|game| game.uuid)
                 .collect())

--- a/server/src/services/game_progression_service.rs
+++ b/server/src/services/game_progression_service.rs
@@ -68,11 +68,24 @@ where
             return Ok(());
         };
 
-        if game.status == GameStatus::Closed || previous_next_update > now {
+        if game.status == GameStatus::Closed || game.status == GameStatus::Aborted || previous_next_update > now {
             return Ok(());
         }
 
         let latest_phase = game.phases.pop().expect("game should have at least one phase");
+
+        // 募集不成立チェック: Ready フェイズ到達時点でプレイヤーが 7 人未満なら中止
+        if matches!(latest_phase.kind, crate::domain::PhaseKind::Ready(_))
+            && game.status != GameStatus::InProgress
+            && game.players.iter().filter(|p| p.power.is_some()).count() < 7
+        {
+            game.phases.push(latest_phase);
+            game.status = GameStatus::Aborted;
+            game.next_update_at = None;
+            self.game_repository.update(&game).map_err(GameProgressionError::Repository)?;
+            return Ok(());
+        }
+
         let owner_accepting_draw_on_main = Self::is_owner_accepting_draw(&game) && Self::is_draw_applicable_phase(&latest_phase);
 
         let mut context = PhaseContext::new();
@@ -384,11 +397,60 @@ mod tests {
             }],
             phases: vec![Phase::new_ready()],
             status: GameStatus::Preparing,
-            is_canceled: false,
             is_draw: false,
             is_solo: false,
             next_update_at: next_update,
         }
+    }
+
+    /// 全 7 プレイヤーが揃った状態のゲームを生成するヘルパー
+    fn sample_full_game(next_update: Option<chrono::NaiveDateTime>) -> Game {
+        use strum::IntoEnumIterator;
+        let mut game = sample_game(next_update);
+        for power in Power::iter().filter(|p| *p != Power::France) {
+            game.players.push(Player {
+                user_uuid: uuid::Uuid::now_v7(),
+                power: Some(power),
+                is_accepting_draw: false,
+                is_owner: false,
+                requested_power: Some(power),
+            });
+        }
+        game
+    }
+
+    /// 指定した regulation で全 7 プレイヤーが揃った状態のゲームを生成するヘルパー
+    fn sample_full_game_with_regulation(next_update: Option<chrono::NaiveDateTime>, regulation: Regulation) -> Game {
+        use strum::IntoEnumIterator;
+        let mut game = sample_game_with_regulation(next_update, regulation);
+        for power in Power::iter().filter(|p| *p != Power::France) {
+            game.players.push(Player {
+                user_uuid: uuid::Uuid::now_v7(),
+                power: Some(power),
+                is_accepting_draw: false,
+                is_owner: false,
+                requested_power: Some(power),
+            });
+        }
+        game
+    }
+
+    /// `sample_full_game` の全プレイヤーに対応する UserRecord 一覧を生成するヘルパー
+    fn users_for_full_game(game: &Game, last_access_at: chrono::DateTime<chrono::Utc>) -> Vec<UserRecord> {
+        game.players
+            .iter()
+            .map(|p| UserRecord {
+                id: 1,
+                uuid: p.user_uuid,
+                discord_user_id: format!("discord-{}", p.user_uuid),
+                username: format!("user-{}", p.user_uuid),
+                global_name: None,
+                avatar_hash: None,
+                avatar_url: None,
+                access_token: format!("token-{}", p.user_uuid),
+                last_access_at,
+            })
+            .collect()
     }
 
     fn user_for(game: &Game, power: Power, last_access_at: chrono::DateTime<chrono::Utc>) -> UserRecord {
@@ -441,8 +503,8 @@ mod tests {
     fn progress_games_updates_when_next_update_is_in_past() {
         let past_date = (chrono::Utc::now().naive_utc() - chrono::Duration::days(1)).date();
         let past = past_date.and_hms_opt(14, 32, 0).expect("valid datetime");
-        let game = sample_game(Some(past));
-        let users = InMemoryUserRepository::new(vec![user_for(&game, Power::France, chrono::Utc::now())]);
+        let game = sample_full_game(Some(past));
+        let users = InMemoryUserRepository::new(users_for_full_game(&game, chrono::Utc::now()));
         let repository = InMemoryGameRepository::new(vec![game]);
         let service = GameProgressionService::new(users, repository.clone());
 
@@ -469,8 +531,8 @@ mod tests {
         .expect("valid regulation");
         let past_date = (chrono::Utc::now().naive_utc() - chrono::Duration::days(1)).date();
         let past = past_date.and_hms_opt(14, 32, 0).expect("valid datetime");
-        let game = sample_game_with_regulation(Some(past), regulation);
-        let users = InMemoryUserRepository::new(vec![user_for(&game, Power::France, chrono::Utc::now())]);
+        let game = sample_full_game_with_regulation(Some(past), regulation);
+        let users = InMemoryUserRepository::new(users_for_full_game(&game, chrono::Utc::now()));
         let repository = InMemoryGameRepository::new(vec![game]);
         let service = GameProgressionService::new(users, repository.clone());
 
@@ -674,5 +736,47 @@ mod tests {
         service.mark_idle_owners_accepting_draw().expect("should succeed");
 
         assert_eq!(repository.updated_len(), 0);
+    }
+
+    #[test]
+    fn progress_games_aborts_when_ready_phase_has_fewer_than_7_players() {
+        let past_date = (chrono::Utc::now().naive_utc() - chrono::Duration::days(1)).date();
+        let past = past_date.and_hms_opt(14, 32, 0).expect("valid datetime");
+
+        // Ready フェイズ・プレイヤー 1 人（7 人未満）
+        let mut game = sample_game(Some(past));
+        assert_eq!(game.players.iter().filter(|p| p.power.is_some()).count(), 1);
+
+        let users = InMemoryUserRepository::new(vec![user_for(&game, Power::France, chrono::Utc::now())]);
+        let repository = InMemoryGameRepository::new(vec![game]);
+        let service = GameProgressionService::new(users, repository.clone());
+
+        service.progress_games().expect("progress should succeed");
+
+        assert_eq!(repository.updated_len(), 1);
+        let updated = repository.updated_first().expect("updated game should exist");
+        assert_eq!(updated.status, GameStatus::Aborted);
+        assert!(updated.next_update_at.is_none());
+        // Ready フェイズが履歴に残っている
+        assert!(matches!(
+            updated.phases.last().expect("phase should exist").kind,
+            crate::domain::PhaseKind::Ready(_)
+        ));
+    }
+
+    #[test]
+    fn progress_games_does_not_abort_when_ready_phase_has_7_players() {
+        let past_date = (chrono::Utc::now().naive_utc() - chrono::Duration::days(1)).date();
+        let past = past_date.and_hms_opt(14, 32, 0).expect("valid datetime");
+
+        let game = sample_full_game(Some(past));
+        let users = InMemoryUserRepository::new(users_for_full_game(&game, chrono::Utc::now()));
+        let repository = InMemoryGameRepository::new(vec![game]);
+        let service = GameProgressionService::new(users, repository.clone());
+
+        service.progress_games().expect("progress should succeed");
+
+        let updated = repository.updated_first().expect("updated game should exist");
+        assert_eq!(updated.status, GameStatus::InProgress);
     }
 }

--- a/server/src/services/game_service.rs
+++ b/server/src/services/game_service.rs
@@ -117,7 +117,6 @@ where
             players: vec![owner],
             phases: vec![Phase::new_ready()],
             status: GameStatus::Preparing,
-            is_canceled: false,
             is_draw: false,
             is_solo: false,
             next_update_at: Some(next_update),


### PR DESCRIPTION
- GameStatus に Aborted を追加する。
- 更新処理実行時にプレイヤーが７人未満の場合は Phase.close() を呼ばずに 卓のステータスを Aborted に変更して終了する。
- Aborted は Closed 同様、以後更新対象にならない。