### PR TITLE
卓主権限によるユニット編集 API を PUT/DELETE に分割

### DIFF
--- a/docs/api/admin-games-units.md
+++ b/docs/api/admin-games-units.md
@@ -1,6 +1,4 @@
-# PUT /admin/games/:game_uuid/units/:location
-
-# DELETE /admin/games/:game_uuid/units/:location
+# /admin/games/:game_uuid/units/:location
 
 ## 概要
 

--- a/docs/api/admin-games-units.md
+++ b/docs/api/admin-games-units.md
@@ -1,108 +1,54 @@
-# PUT /admin/games/:game_uuid/units
+# PUT /admin/games/:game_uuid/units/:location
+
+# DELETE /admin/games/:game_uuid/units/:location
 
 ## 概要
 
-- 卓主が自分の卓のユニットを配置・置換・削除する API
-- `unit` を指定するとユニットを配置し、省略または `null` にすると `location` のユニットを削除する
+- 卓主が自分の卓のユニットを操作する API
+- `PUT`: 指定地点のユニットを配置または置換
+- `DELETE`: 指定地点のユニットを削除
 - 既存ユニットと配置先が重複する場合は既存ユニットおよびその命令を削除してから新ユニットを配置する
 
 ## HTTP
 
-- Method: `PUT`
-- Path: `/admin/games/:game_uuid/units`
-- Content-Type: `application/json`
+- `PUT /admin/games/:game_uuid/units/:location`
+- `DELETE /admin/games/:game_uuid/units/:location`
 
 ## ヘッダ
 
 - Authorization: 必須（`Bearer <access_token>`）
-- Content-Type: `application/json`
+- Content-Type: `application/json`（`PUT` のみ）
 
 ## パスパラメータ
 
 - `game_uuid` (`string`): 対象の卓の UUID（UUID v7 形式）
+- `location` (`string`): 地域コード（例: `par`, `lon`, `spa_nc`）
 
-## リクエストボディ
-
-### 型
-
-- `object`
-
-### 必須パラメータ
-
-- `location` (`string`)
-
-### 任意パラメータ
-
-- `unit` (`object | null`)
-
-### 値定義
-
-#### `location`
-
-- 地域コード文字列（例: `"par"`, `"lon"`, `"spa_nc"`）
-- 存在しないコードは `400 Bad Request`
-- 双海岸地域（`spa` など）に海軍を配置する場合は海岸バリアントコード（`"spa_nc"` / `"spa_sc"`）を指定すること
-
-#### `unit`
-
-- `null` または省略: 指定 `location` のユニットを削除する
-- 存在しない場合: 削除操作
-
-##### `unit.power` (`string`)
-
-- 担当国を示す1文字コード: `"a" | "e" | "f" | "g" | "i" | "r" | "t"`
-- 上記以外は `400 Bad Request`
-
-##### `unit.kind` (`string`)
-
-- ユニット種別:
-  - `"a"` または `"army"` → 陸軍
-  - `"f"` または `"fleet"` → 海軍
-- 上記以外は `400 Bad Request`
-
-## リクエスト例
-
-### 陸軍配置
+## PUT リクエストボディ
 
 ```json
 {
-  "unit": { "power": "f", "kind": "a" },
-  "location": "par"
+  "unit": {
+    "power": "f",
+    "kind": "a"
+  }
 }
 ```
 
-### 海軍配置（海岸バリアント指定）
+### `unit.power` (`string`)
 
-```json
-{
-  "unit": { "power": "f", "kind": "f" },
-  "location": "bre"
-}
-```
+- 担当国1文字コード: `a | e | f | g | i | r | t`
 
-### 双海岸地域への海軍配置
+### `unit.kind` (`string`)
 
-```json
-{
-  "unit": { "power": "f", "kind": "f" },
-  "location": "spa_nc"
-}
-```
-
-### ユニット削除
-
-```json
-{
-  "unit": null,
-  "location": "par"
-}
-```
+- `a` または `army`（陸軍）
+- `f` または `fleet`（海軍）
 
 ## 成功レスポンス
 
 - Status: `200 OK`
 
-### ユニット配置・置換時
+### PUT（配置・置換）
 
 ```json
 {
@@ -115,7 +61,7 @@
 }
 ```
 
-### ユニット削除時
+### DELETE（削除）
 
 ```json
 {
@@ -124,11 +70,6 @@
   "unit": null
 }
 ```
-
-注意:
-
-- `unit.power` はレスポンスで1文字コードを返す（例: `"f"`）
-- `unit.kind` はレスポンスでシンボル文字を返す（陸軍: `"A"`, 海軍: `"F"`）
 
 ## エラー形式（共通）
 
@@ -143,31 +84,19 @@
 
 ### `400 Bad Request` — `code: invalid_request`
 
-#### `Authorization` ヘッダ関連
-
 | 条件 | `message` |
 |---|---|
 | Authorization ヘッダ欠落 | `"authorization header is required"` |
 | Authorization 形式不正（Bearer プレフィックスなし） | `"authorization must start with 'Bearer <token>'"` |
 | アクセストークン空（Bearer 後が空文字） | `"access token is required"` |
-
-#### パスパラメータ検証
-
-| 条件 | `message` |
-|---|---|
 | `game_uuid` が有効な UUID でない | `"game_uuid is invalid"` |
-
-#### リクエストボディ検証
-
-| 条件 | `message` |
-|---|---|
 | `location` が無効な地域コード | `"invalid location: <location>"` |
-| `unit.power` が無効な国コード | `"invalid power: <power>"` |
-| `unit.kind` が無効な値 | `"invalid unit kind: <kind>"` |
-| 陸軍を海域に配置しようとした | `"army cannot be placed in a sea province"` |
-| 陸軍を海岸バリアントコードで指定した | `"army cannot be placed on a coast variant location"` |
-| 海軍を内陸に配置しようとした | `"fleet cannot be placed in an inland province"` |
-| 海軍を双海岸地域のベースコードで指定した（バリアント指定なし） | `"fleet must specify a coast variant for this location"` |
+| `unit.power` が無効な国コード（PUT） | `"invalid power: <power>"` |
+| `unit.kind` が無効な値（PUT） | `"invalid unit kind: <kind>"` |
+| 陸軍を海域に配置しようとした（PUT） | `"army cannot be placed in a sea province"` |
+| 陸軍を海岸バリアントコードで指定した（PUT） | `"army cannot be placed on a coast variant location"` |
+| 海軍を内陸に配置しようとした（PUT） | `"fleet cannot be placed in an inland province"` |
+| 海軍を双海岸地域のベースコードで指定した（PUT） | `"fleet must specify a coast variant for this location"` |
 
 ### `401 Unauthorized` — `code: unauthorized`
 
@@ -181,7 +110,7 @@
 |---|---|
 | リクエストユーザーが当該卓の卓主でない | `"user is not the owner of this game"` |
 | 卓にフェイズが存在しない | `"game has no phases"` |
-| 現在の最新フェイズがメインフェイズ（春命令・秋命令）以外 | `"units can only be set during a main phase"` |
+| 最新フェイズがメインフェイズ以外 | `"units can only be set during a main phase"` |
 
 ### `404 Not Found` — `code: not_found`
 
@@ -197,36 +126,32 @@
 
 ## ビジネスルール
 
-- メインフェイズ制限: 最新フェイズが `SpringMain`（春命令）または `FallMain`（秋命令）のときのみ操作可能
-- 既存ユニット置換: 同じベースコードにユニットが既に存在する場合、既存ユニットとその関連命令（直接命令・支援対象・輸送対象を含む）をすべて削除してから新ユニットを配置する
-- Hold 命令自動生成: 新ユニット配置時、そのユニットの Hold 命令を自動で生成する
-- システムメッセージ: ユニットの状態が変化した場合にメッセージ DB へ追記する
+- メインフェイズ制限: 最新フェイズが `SpringMain` または `FallMain` のときのみ操作可能
+- 既存ユニット置換: 同じベースコードに既存ユニットがある場合、既存ユニットと関連命令を削除してから新ユニットを配置
+- Hold 命令自動生成: PUT で新ユニット配置時に Hold 命令を自動生成
+- システムメッセージ: ユニット状態が変化した場合のみメッセージ DB に追記（同じ状態への再適用では追記しない）
 
 | 操作 | 追記されるメッセージ |
 |---|---|
-| 新規配置（旧ユニットなし → 新ユニットあり） | `UnitPlaced` |
-| 置換（旧ユニットあり → 新ユニットあり） | `UnitReplaced` |
-| 削除（旧ユニットあり → 新ユニットなし） | `UnitRemoved` |
-| 変化なし（旧ユニットなし → 新ユニットなし） | なし |
-
-- 排他制御: サーバー全体の `game_update_lock` を取得した上で実行される
+| 新規配置（旧なし → 新あり） | `UnitPlaced` |
+| 置換（旧あり → 新あり、内容が異なる） | `UnitReplaced` |
+| 削除（旧あり → 新なし） | `UnitRemoved` |
+| 変化なし（旧新が同一） | なし |
 
 ## curl
 
-### 陸軍配置
+### 陸軍配置（PUT）
 
 ```bash
-curl -X PUT '{base_path}/admin/games/{game_uuid}/units' \
+curl -X PUT '{base_path}/admin/games/{game_uuid}/units/par' \
   -H 'Authorization: Bearer <access_token>' \
   -H 'Content-Type: application/json' \
-  -d '{"unit":{"power":"f","kind":"a"},"location":"par"}'
+  -d '{"unit":{"power":"f","kind":"a"}}'
 ```
 
-### ユニット削除
+### ユニット削除（DELETE）
 
 ```bash
-curl -X PUT '{base_path}/admin/games/{game_uuid}/units' \
-  -H 'Authorization: Bearer <access_token>' \
-  -H 'Content-Type: application/json' \
-  -d '{"unit":null,"location":"par"}'
+curl -X DELETE '{base_path}/admin/games/{game_uuid}/units/par' \
+  -H 'Authorization: Bearer <access_token>'
 ```

--- a/docs/api/delete-admin-games-units.md
+++ b/docs/api/delete-admin-games-units.md
@@ -1,0 +1,87 @@
+# DELETE /admin/games/:game_uuid/units/:location
+
+## 概要
+
+- 卓主が自分の卓の指定地点のユニットを削除する API
+
+## HTTP
+
+- Method: `DELETE`
+- Path: `/admin/games/:game_uuid/units/:location`
+
+## ヘッダ
+
+- Authorization: 必須（`Bearer <access_token>`）
+
+## パスパラメータ
+
+- `game_uuid` (`string`): 対象の卓の UUID（UUID v7 形式）
+- `location` (`string`): 地域コード（例: `par`, `lon`, `spa_nc`）
+
+## リクエストボディ
+
+なし
+
+## 成功レスポンス
+
+- Status: `200 OK`
+
+```json
+{
+  "game_uuid": "019715e1-b123-7abc-8def-000000000001",
+  "location": "par",
+  "unit": null
+}
+```
+
+## エラー形式
+
+```json
+{
+  "code": "invalid_request | unauthorized | not_found | forbidden | repository_error",
+  "message": "人間向け説明"
+}
+```
+
+## エラーケース
+
+### `400 Bad Request` — `code: invalid_request`
+
+| 条件 | `message` |
+|---|---|
+| Authorization ヘッダ欠落 | `"authorization header is required"` |
+| Authorization 形式不正（Bearer プレフィックスなし） | `"authorization must start with 'Bearer <token>'"` |
+| アクセストークン空（Bearer 後が空文字） | `"access token is required"` |
+| `game_uuid` が有効な UUID でない | `"game_uuid is invalid"` |
+| `location` が無効な地域コード | `"invalid location: <location>"` |
+
+### `401 Unauthorized` — `code: unauthorized`
+
+| 条件 | `message` |
+|---|---|
+| アクセストークン未登録（DB にユーザーレコードが存在しない） | `"unauthorized"` |
+
+### `403 Forbidden` — `code: forbidden`
+
+| 条件 | `message` |
+|---|---|
+| リクエストユーザーが当該卓の卓主でない | `"user is not the owner of this game"` |
+| 卓にフェイズが存在しない | `"game has no phases"` |
+| 最新フェイズがメインフェイズ以外 | `"units can only be set during a main phase"` |
+
+### `404 Not Found` — `code: not_found`
+
+| 条件 | `message` |
+|---|---|
+| 指定した UUID の卓が存在しない | `"game not found"` |
+
+### `500 Internal Server Error` — `code: repository_error`
+
+| 条件 | `message` |
+|---|---|
+| データベース障害 | `"repository error: ..."` |
+
+## ビジネスルール
+
+- メインフェイズ制限: 最新フェイズが `SpringMain` または `FallMain` のときのみ操作可能
+- システムメッセージ: ユニット状態が変化した場合のみメッセージ DB に追記（指定地点にユニットが存在しない場合は追記しない）

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -34,7 +34,8 @@
 
 | メソッド | パス | 概要 | 備考 |
 | --- | --- | --- | --- |
-| `PUT` | [`/admin/games/{id}/units`](./admin-games-units.md) | ユニットの登録、変更、削除 | メインフェイズのみ |
+| `PUT` | [`/admin/games/{id}/units/{location}`](./admin-games-units.md) | ユニットの登録、変更 | メインフェイズのみ |
+| `DELETE` | [`/admin/games/{id}/units/{location}`](./admin-games-units.md) | ユニットの削除 | メインフェイズのみ |
 | `PUT` | `/admin/games/{id}/territories` | 占領情報の登録、変更、削除 | メインフェイズのみ |
 | `PUT` | `/admin/games/{id}/progress-mode` | 進行モードを合意進行に切り替える | メインフェイズのみ |
 | `PUT` | `/admin/games/{id}/next-update-at` | 次回更新時刻を変更する | メインフェイズのみ |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -34,8 +34,8 @@
 
 | メソッド | パス | 概要 | 備考 |
 | --- | --- | --- | --- |
-| `PUT` | [`/admin/games/{id}/units/{location}`](./admin-games-units.md) | ユニットの登録、変更 | メインフェイズのみ |
-| `DELETE` | [`/admin/games/{id}/units/{location}`](./admin-games-units.md) | ユニットの削除 | メインフェイズのみ |
+| `PUT` | [`/admin/games/{id}/units/{location}`](./put-admin-games-units.md) | ユニットの登録、変更 | メインフェイズのみ |
+| `DELETE` | [`/admin/games/{id}/units/{location}`](./delete-admin-games-units.md) | ユニットの削除 | メインフェイズのみ |
 | `PUT` | `/admin/games/{id}/territories` | 占領情報の登録、変更、削除 | メインフェイズのみ |
 | `PUT` | `/admin/games/{id}/progress-mode` | 進行モードを合意進行に切り替える | メインフェイズのみ |
 | `PUT` | `/admin/games/{id}/next-update-at` | 次回更新時刻を変更する | メインフェイズのみ |

--- a/docs/api/put-admin-games-units.md
+++ b/docs/api/put-admin-games-units.md
@@ -1,28 +1,27 @@
-# /admin/games/:game_uuid/units/:location
+# PUT /admin/games/:game_uuid/units/:location
 
 ## 概要
 
-- 卓主が自分の卓のユニットを操作する API
-- `PUT`: 指定地点のユニットを配置または置換
-- `DELETE`: 指定地点のユニットを削除
+- 卓主が自分の卓の指定地点にユニットを配置または置換する API
 - 既存ユニットと配置先が重複する場合は既存ユニットおよびその命令を削除してから新ユニットを配置する
 
 ## HTTP
 
-- `PUT /admin/games/:game_uuid/units/:location`
-- `DELETE /admin/games/:game_uuid/units/:location`
+- Method: `PUT`
+- Path: `/admin/games/:game_uuid/units/:location`
+- Content-Type: `application/json`
 
 ## ヘッダ
 
 - Authorization: 必須（`Bearer <access_token>`）
-- Content-Type: `application/json`（`PUT` のみ）
+- Content-Type: `application/json`
 
 ## パスパラメータ
 
 - `game_uuid` (`string`): 対象の卓の UUID（UUID v7 形式）
 - `location` (`string`): 地域コード（例: `par`, `lon`, `spa_nc`）
 
-## PUT リクエストボディ
+## リクエストボディ
 
 ```json
 {
@@ -46,8 +45,6 @@
 
 - Status: `200 OK`
 
-### PUT（配置・置換）
-
 ```json
 {
   "game_uuid": "019715e1-b123-7abc-8def-000000000001",
@@ -59,17 +56,7 @@
 }
 ```
 
-### DELETE（削除）
-
-```json
-{
-  "game_uuid": "019715e1-b123-7abc-8def-000000000001",
-  "location": "par",
-  "unit": null
-}
-```
-
-## エラー形式（共通）
+## エラー形式
 
 ```json
 {
@@ -78,7 +65,7 @@
 }
 ```
 
-## 全エラーケース
+## エラーケース
 
 ### `400 Bad Request` — `code: invalid_request`
 
@@ -89,12 +76,12 @@
 | アクセストークン空（Bearer 後が空文字） | `"access token is required"` |
 | `game_uuid` が有効な UUID でない | `"game_uuid is invalid"` |
 | `location` が無効な地域コード | `"invalid location: <location>"` |
-| `unit.power` が無効な国コード（PUT） | `"invalid power: <power>"` |
-| `unit.kind` が無効な値（PUT） | `"invalid unit kind: <kind>"` |
-| 陸軍を海域に配置しようとした（PUT） | `"army cannot be placed in a sea province"` |
-| 陸軍を海岸バリアントコードで指定した（PUT） | `"army cannot be placed on a coast variant location"` |
-| 海軍を内陸に配置しようとした（PUT） | `"fleet cannot be placed in an inland province"` |
-| 海軍を双海岸地域のベースコードで指定した（PUT） | `"fleet must specify a coast variant for this location"` |
+| `unit.power` が無効な国コード | `"invalid power: <power>"` |
+| `unit.kind` が無効な値 | `"invalid unit kind: <kind>"` |
+| 陸軍を海域に配置しようとした | `"army cannot be placed in a sea province"` |
+| 陸軍を海岸バリアントコードで指定した | `"army cannot be placed on a coast variant location"` |
+| 海軍を内陸に配置しようとした | `"fleet cannot be placed in an inland province"` |
+| 海軍を双海岸地域のベースコードで指定した | `"fleet must specify a coast variant for this location"` |
 
 ### `401 Unauthorized` — `code: unauthorized`
 
@@ -126,30 +113,5 @@
 
 - メインフェイズ制限: 最新フェイズが `SpringMain` または `FallMain` のときのみ操作可能
 - 既存ユニット置換: 同じベースコードに既存ユニットがある場合、既存ユニットと関連命令を削除してから新ユニットを配置
-- Hold 命令自動生成: PUT で新ユニット配置時に Hold 命令を自動生成
+- Hold 命令自動生成: 新ユニット配置時に Hold 命令を自動生成
 - システムメッセージ: ユニット状態が変化した場合のみメッセージ DB に追記（同じ状態への再適用では追記しない）
-
-| 操作 | 追記されるメッセージ |
-|---|---|
-| 新規配置（旧なし → 新あり） | `UnitPlaced` |
-| 置換（旧あり → 新あり、内容が異なる） | `UnitReplaced` |
-| 削除（旧あり → 新なし） | `UnitRemoved` |
-| 変化なし（旧新が同一） | なし |
-
-## curl
-
-### 陸軍配置（PUT）
-
-```bash
-curl -X PUT '{base_path}/admin/games/{game_uuid}/units/par' \
-  -H 'Authorization: Bearer <access_token>' \
-  -H 'Content-Type: application/json' \
-  -d '{"unit":{"power":"f","kind":"a"}}'
-```
-
-### ユニット削除（DELETE）
-
-```bash
-curl -X DELETE '{base_path}/admin/games/{game_uuid}/units/par' \
-  -H 'Authorization: Bearer <access_token>'
-```

--- a/docs/game-update-flow.md
+++ b/docs/game-update-flow.md
@@ -29,7 +29,7 @@ run_global_pre_handler（ミドルウェア）
     │
     ▼
 各ハンドラ実行（ロック外）
-    │   ※ PUT draw-proposal / PUT units は再度 game_update_lock を取得して実行
+    │   ※ PUT draw-proposal / PUT units / DELETE units は再度 game_update_lock を取得して実行
     ▼
 レスポンス返却
 ```

--- a/docs/locking-control.md
+++ b/docs/locking-control.md
@@ -52,7 +52,8 @@ drop(_game_update_guard);
 |---|---|---|---|
 | グローバルプリハンドラ（`run_global_pre_handler`） | `pre_handler.run()` 呼び出し前 | `pre_handler.run()` 完了後（ハンドラ実行前） | 自動進行（定時更新）を直列化 |
 | `PUT /admin/games/:game_uuid/draw-proposal` | ハンドラ本体の先頭 | ハンドラ本体の末尾 | 講和フラグ更新 |
-| `PUT /admin/games/:game_uuid/units` | ハンドラ本体の先頭 | ハンドラ本体の末尾 | ユニット配置・削除 |
+| `PUT /admin/games/:game_uuid/units/:location` | ハンドラ本体の先頭 | ハンドラ本体の末尾 | ユニット配置・置換 |
+| `DELETE /admin/games/:game_uuid/units/:location` | ハンドラ本体の先頭 | ハンドラ本体の末尾 | ユニット削除 |
 
 ### ロックを取得しないエンドポイント
 
@@ -78,12 +79,12 @@ run_global_pre_handler
     │
     ▼
 各ハンドラ実行（ロック外）
-    │ ※ draw-proposal / units は再度 game_update_lock を取得
+    │ ※ draw-proposal / units(put/delete) は再度 game_update_lock を取得
     ▼
 レスポンス返却
 ```
 
-プリハンドラはロックを解放してからハンドラに制御を渡す。draw-proposal・units ハンドラは再度ロックを取得するため、同一リクエスト内で定時進行と操作が衝突することはない。
+プリハンドラはロックを解放してからハンドラに制御を渡す。draw-proposal・units(put/delete) ハンドラは再度ロックを取得するため、同一リクエスト内で定時進行と操作が衝突することはない。
 
 ---
 

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -29,6 +29,7 @@ pub(crate) use requests::SetDrawProposalRequestValidationError;
 pub(crate) use requests::SetUnitRequest;
 pub(crate) use requests::SetUnitRequestBody;
 pub(crate) use requests::SetUnitRequestValidationError;
+pub(crate) use requests::UnitSpecBody;
 pub(crate) use responses::ApiErrorResponse;
 pub(crate) use responses::AuthLoginResponse;
 pub(crate) use responses::AuthLoginResponseUser;

--- a/server/src/api/handlers.rs
+++ b/server/src/api/handlers.rs
@@ -16,6 +16,7 @@ pub(crate) use error::CreateGameHandlerError;
 pub(crate) use error::JoinGameHandlerError;
 pub(crate) use error::SetDrawProposalHandlerError;
 pub(crate) use error::SetUnitHandlerError;
+pub(crate) use game_handler::delete_admin_games_units;
 pub(crate) use game_handler::post_games;
 pub(crate) use game_handler::post_games_players;
 pub(crate) use game_handler::put_admin_games_draw_proposal;

--- a/server/src/api/handlers.rs
+++ b/server/src/api/handlers.rs
@@ -71,5 +71,6 @@ pub(crate) use super::SetUnitResponse;
 pub(crate) use super::SqliteMessageRepository;
 pub(crate) use super::UnitResponseBody;
 pub(crate) use super::UnitSpec;
+pub(crate) use super::UnitSpecBody;
 pub(crate) use super::User;
 pub(crate) use super::UserRepository;

--- a/server/src/api/handlers/game_handler.rs
+++ b/server/src/api/handlers/game_handler.rs
@@ -510,7 +510,7 @@ where
 ///
 pub(crate) async fn put_admin_games_units<U, G, D>(
     State(state): State<AppState<U, G, D>>,
-    Path(game_uuid_str): Path<String>,
+    Path((game_uuid_str, location)): Path<(String, String)>,
     headers: HeaderMap,
     Json(body): Json<SetUnitRequestBody>,
 ) -> impl IntoResponse
@@ -539,8 +539,77 @@ where
     let request = SetUnitRequest {
         authorization,
         game_uuid,
-        unit: body.unit,
-        location: body.location,
+        unit: Some(body.unit),
+        location,
+    };
+
+    let state_clone = state.clone();
+    let request_clone = request.clone();
+
+    let _game_update_guard = state.game_update_lock.lock().await;
+    let result = tokio::task::spawn_blocking(move || {
+        match handle_set_unit(
+            &state_clone.game_service,
+            state_clone.message_repository.as_ref(),
+            request_clone,
+        ) {
+            Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+            Err(error) => {
+                let status = match &error {
+                    SetUnitHandlerError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
+                    SetUnitHandlerError::Service(SetUnitError::Unauthorized) => StatusCode::UNAUTHORIZED,
+                    SetUnitHandlerError::Service(SetUnitError::NotFound) => StatusCode::NOT_FOUND,
+                    SetUnitHandlerError::Service(SetUnitError::Forbidden(_)) => StatusCode::FORBIDDEN,
+                    SetUnitHandlerError::Service(SetUnitError::InvalidRequest(_)) => StatusCode::BAD_REQUEST,
+                    _ => StatusCode::INTERNAL_SERVER_ERROR,
+                };
+                (status, Json(error.to_api_error_response())).into_response()
+            }
+        }
+    })
+    .await;
+    drop(_game_update_guard);
+    match result {
+        Ok(response) => response,
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+///
+/// ユニット削除リクエスト Axum ハンドラ関数
+///
+pub(crate) async fn delete_admin_games_units<U, G, D>(
+    State(state): State<AppState<U, G, D>>,
+    Path((game_uuid_str, location)): Path<(String, String)>,
+    headers: HeaderMap,
+) -> impl IntoResponse
+where
+    U: UserRepository + Send + Sync + 'static,
+    G: GameRepository + Send + Sync + 'static,
+    D: DiscordIdentityProvider + Send + Sync + 'static,
+{
+    let game_uuid = match game_uuid_str.parse::<Uuid>() {
+        Ok(uuid) => uuid,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(SetUnitHandlerError::InvalidRequest(SetUnitRequestValidationError::InvalidGameUuid).to_api_error_response()),
+            )
+                .into_response();
+        }
+    };
+
+    let authorization = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+
+    let request = SetUnitRequest {
+        authorization,
+        game_uuid,
+        unit: None,
+        location,
     };
 
     let state_clone = state.clone();
@@ -606,23 +675,25 @@ where
     let turn = result.game.current_turn();
     let game_uuid = result.game.uuid;
 
-    match (result.old_unit, result.new_unit) {
-        (None, Some(new_unit)) => {
-            if let Err(error) = message_repository.append_unit_placed_message(game_uuid, &turn, new_unit) {
-                eprintln!("failed to persist UnitPlaced message (game_uuid={}): {}", game_uuid, error);
+    if result.changed {
+        match (result.old_unit, result.new_unit) {
+            (None, Some(new_unit)) => {
+                if let Err(error) = message_repository.append_unit_placed_message(game_uuid, &turn, new_unit) {
+                    eprintln!("failed to persist UnitPlaced message (game_uuid={}): {}", game_uuid, error);
+                }
             }
-        }
-        (Some(old_unit), Some(new_unit)) => {
-            if let Err(error) = message_repository.append_unit_replaced_message(game_uuid, &turn, old_unit, new_unit) {
-                eprintln!("failed to persist UnitReplaced message (game_uuid={}): {}", game_uuid, error);
+            (Some(old_unit), Some(new_unit)) => {
+                if let Err(error) = message_repository.append_unit_replaced_message(game_uuid, &turn, old_unit, new_unit) {
+                    eprintln!("failed to persist UnitReplaced message (game_uuid={}): {}", game_uuid, error);
+                }
             }
-        }
-        (Some(old_unit), None) => {
-            if let Err(error) = message_repository.append_unit_removed_message(game_uuid, &turn, old_unit) {
-                eprintln!("failed to persist UnitRemoved message (game_uuid={}): {}", game_uuid, error);
+            (Some(old_unit), None) => {
+                if let Err(error) = message_repository.append_unit_removed_message(game_uuid, &turn, old_unit) {
+                    eprintln!("failed to persist UnitRemoved message (game_uuid={}): {}", game_uuid, error);
+                }
             }
+            (None, None) => {}
         }
-        (None, None) => {}
     }
 
     let unit_body = result.new_unit.map(|u| UnitResponseBody {

--- a/server/src/api/handlers/game_handler.rs
+++ b/server/src/api/handlers/game_handler.rs
@@ -8,6 +8,7 @@ use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use axum::response::Response;
 use chrono::NaiveDate;
 use uuid::Uuid;
 
@@ -50,6 +51,7 @@ use super::SetUnitResponse;
 use super::SqliteMessageRepository;
 use super::UnitResponseBody;
 use super::UnitSpec;
+use super::UnitSpecBody;
 use super::User;
 use super::UserRepository;
 
@@ -519,60 +521,7 @@ where
     G: GameRepository + Send + Sync + 'static,
     D: DiscordIdentityProvider + Send + Sync + 'static,
 {
-    let game_uuid = match game_uuid_str.parse::<Uuid>() {
-        Ok(uuid) => uuid,
-        Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(SetUnitHandlerError::InvalidRequest(SetUnitRequestValidationError::InvalidGameUuid).to_api_error_response()),
-            )
-                .into_response();
-        }
-    };
-
-    let authorization = headers
-        .get("authorization")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("")
-        .to_string();
-
-    let request = SetUnitRequest {
-        authorization,
-        game_uuid,
-        unit: Some(body.unit),
-        location,
-    };
-
-    let state_clone = state.clone();
-    let request_clone = request.clone();
-
-    let _game_update_guard = state.game_update_lock.lock().await;
-    let result = tokio::task::spawn_blocking(move || {
-        match handle_set_unit(
-            &state_clone.game_service,
-            state_clone.message_repository.as_ref(),
-            request_clone,
-        ) {
-            Ok(response) => (StatusCode::OK, Json(response)).into_response(),
-            Err(error) => {
-                let status = match &error {
-                    SetUnitHandlerError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
-                    SetUnitHandlerError::Service(SetUnitError::Unauthorized) => StatusCode::UNAUTHORIZED,
-                    SetUnitHandlerError::Service(SetUnitError::NotFound) => StatusCode::NOT_FOUND,
-                    SetUnitHandlerError::Service(SetUnitError::Forbidden(_)) => StatusCode::FORBIDDEN,
-                    SetUnitHandlerError::Service(SetUnitError::InvalidRequest(_)) => StatusCode::BAD_REQUEST,
-                    _ => StatusCode::INTERNAL_SERVER_ERROR,
-                };
-                (status, Json(error.to_api_error_response())).into_response()
-            }
-        }
-    })
-    .await;
-    drop(_game_update_guard);
-    match result {
-        Ok(response) => response,
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    }
+    dispatch_set_unit(state, game_uuid_str, location, headers, Some(body.unit)).await
 }
 
 ///
@@ -583,6 +532,21 @@ pub(crate) async fn delete_admin_games_units<U, G, D>(
     Path((game_uuid_str, location)): Path<(String, String)>,
     headers: HeaderMap,
 ) -> impl IntoResponse
+where
+    U: UserRepository + Send + Sync + 'static,
+    G: GameRepository + Send + Sync + 'static,
+    D: DiscordIdentityProvider + Send + Sync + 'static,
+{
+    dispatch_set_unit(state, game_uuid_str, location, headers, None).await
+}
+
+async fn dispatch_set_unit<U, G, D>(
+    state: AppState<U, G, D>,
+    game_uuid_str: String,
+    location: String,
+    headers: HeaderMap,
+    unit: Option<UnitSpecBody>,
+) -> Response
 where
     U: UserRepository + Send + Sync + 'static,
     G: GameRepository + Send + Sync + 'static,
@@ -608,7 +572,7 @@ where
     let request = SetUnitRequest {
         authorization,
         game_uuid,
-        unit: None,
+        unit,
         location,
     };
 

--- a/server/src/api/requests/game_request.rs
+++ b/server/src/api/requests/game_request.rs
@@ -155,8 +155,7 @@ pub(crate) struct UnitSpecBody {
 ///
 #[derive(Debug, Deserialize)]
 pub(crate) struct SetUnitRequestBody {
-    pub unit: Option<UnitSpecBody>,
-    pub location: String,
+    pub unit: UnitSpecBody,
 }
 
 ///

--- a/server/src/api/router.rs
+++ b/server/src/api/router.rs
@@ -37,6 +37,7 @@ use super::SqliteGameRepository;
 use super::SqliteMessageRepository;
 use super::SqliteUserRepository;
 use super::UserRepository;
+use super::handlers::delete_admin_games_units;
 use super::handlers::post_auth_login;
 use super::handlers::post_games;
 use super::handlers::post_games_players;
@@ -270,7 +271,10 @@ where
             "/admin/games/:game_uuid/draw-proposal",
             put(put_admin_games_draw_proposal::<U, G, D>),
         )
-        .route("/admin/games/:game_uuid/units", put(put_admin_games_units::<U, G, D>))
+        .route(
+            "/admin/games/:game_uuid/units/:location",
+            put(put_admin_games_units::<U, G, D>).delete(delete_admin_games_units::<U, G, D>),
+        )
         .route("/auth/login", post(post_auth_login::<U, G, D>))
         .with_state(state.clone())
         .layer(from_fn_with_state(state, run_global_pre_handler::<U, G, D>))

--- a/server/src/services/game_service.rs
+++ b/server/src/services/game_service.rs
@@ -118,6 +118,7 @@ pub(crate) struct SetUnitResult {
     pub game: Game,
     pub old_unit: Option<Unit>,
     pub new_unit: Option<Unit>,
+    pub changed: bool,
 }
 
 ///
@@ -518,6 +519,16 @@ where
         // 既存ユニット検索（ベースコードで一致）
         let old_unit = phase.units.iter().find(|u| u.location.code() == location.code()).copied();
 
+        let changed = old_unit != new_unit;
+        if !changed {
+            return Ok(SetUnitResult {
+                game: updated_game,
+                old_unit,
+                new_unit,
+                changed: false,
+            });
+        }
+
         // 既存ユニットを削除（ベースコード一致するものすべて）
         if old_unit.is_some() {
             phase.units.retain(|u| u.location.code() != location.code());
@@ -549,6 +560,7 @@ where
             game: updated_game,
             old_unit,
             new_unit,
+            changed: true,
         })
     }
 }
@@ -2014,6 +2026,40 @@ mod tests {
 
         assert!(result.old_unit.is_none());
         assert!(result.new_unit.is_some());
+    }
+
+    #[test]
+    fn set_unit_returns_unchanged_when_same_unit_is_requested() {
+        let owner_uuid = Uuid::now_v7();
+        let user_repository = InMemoryUserRepository::new(vec![owner_user_record(owner_uuid)]);
+        let mut game = sample_in_progress_game(owner_uuid);
+        let paris = Province::from_code("par").expect("par should be a valid province");
+        let existing = Unit::new_army(Power::France, paris);
+        let phase = game.phases.last_mut().expect("phase should exist");
+        phase.units.push(existing);
+        phase.orders.push(crate::domain::Order::new_hold(Power::France, existing));
+
+        let game_uuid = game.uuid;
+        let game_repository = InMemoryGameRepository::new(vec![game]);
+        let service = GameService::new(user_repository, game_repository.clone());
+
+        let result = service
+            .set_unit(SetUnitCommand {
+                access_token: "token-owner".to_string(),
+                game_uuid,
+                location: "par".to_string(),
+                unit: Some(UnitSpec {
+                    power_symbol: "f".to_string(),
+                    kind_str: "a".to_string(),
+                }),
+            })
+            .expect("should succeed");
+
+        assert!(!result.changed, "changed should be false for no-op update");
+        assert!(
+            game_repository.updated_first().is_none(),
+            "update should not be called for no-op"
+        );
     }
 
     #[test]


### PR DESCRIPTION
- PUT /admin/games/:game_uuid/units を2つのエンドポイントに分割 PUT /admin/games/:game_uuid/units/:location — ユニットの配置・置換 DELETE /admin/games/:game_uuid/units/:location — ユニットの除去
- SetUnitRequestBody から location フィールドを削除（パスパラメータから取得）
- SetUnitResult に changed フラグを追加し、ユニット状態が変化しない場合は game_repository::update およびシステムメッセージ送信をスキップ
- 未使用の `axum::routing::delete` インポートを削除