### PR TITLE
ユニット・占領情報編集 API のフェイズ競合検出処理の実装

### DIFF
--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -20,6 +20,8 @@ pub(crate) use requests::AuthRequestValidationError;
 pub(crate) use requests::CreateGameRequest;
 pub(crate) use requests::CreateGameRequestBody;
 pub(crate) use requests::CreateGameRequestValidationError;
+pub(crate) use requests::DeleteTerritoryQueryParams;
+pub(crate) use requests::DeleteUnitQueryParams;
 pub(crate) use requests::JoinGameRequest;
 pub(crate) use requests::JoinGameRequestBody;
 pub(crate) use requests::JoinGameRequestValidationError;

--- a/server/src/api/handlers.rs
+++ b/server/src/api/handlers.rs
@@ -43,6 +43,8 @@ pub(crate) use super::CreateGameRequest;
 pub(crate) use super::CreateGameRequestBody;
 pub(crate) use super::CreateGameRequestValidationError;
 pub(crate) use super::CreateGameResponse;
+pub(crate) use super::DeleteTerritoryQueryParams;
+pub(crate) use super::DeleteUnitQueryParams;
 pub(crate) use super::DiscordClientError;
 pub(crate) use super::DiscordIdentityProvider;
 pub(crate) use super::GameRepository;

--- a/server/src/api/handlers/error.rs
+++ b/server/src/api/handlers/error.rs
@@ -282,6 +282,9 @@ impl SetUnitHandlerError {
             }
             Self::InvalidRequest(SetUnitRequestValidationError::MissingAccessToken) => "access token is required".to_string(),
             Self::InvalidRequest(SetUnitRequestValidationError::InvalidGameUuid) => "game_uuid is invalid".to_string(),
+            Self::InvalidRequest(SetUnitRequestValidationError::InvalidSeason) => {
+                "season must be in the format like '1901s' or '1901f'".to_string()
+            }
             Self::Service(SetUnitError::Forbidden(message)) | Self::Service(SetUnitError::InvalidRequest(message)) => {
                 message.clone()
             }
@@ -333,6 +336,9 @@ impl SetTerritoryHandlerError {
                 "access token is required".to_string()
             }
             Self::InvalidRequest(SetTerritoryRequestValidationError::InvalidGameUuid) => "game_uuid is invalid".to_string(),
+            Self::InvalidRequest(SetTerritoryRequestValidationError::InvalidSeason) => {
+                "season must be in the format like '1901s' or '1901f'".to_string()
+            }
             Self::Service(SetTerritoryError::Forbidden(message)) | Self::Service(SetTerritoryError::InvalidRequest(message)) => {
                 message.clone()
             }

--- a/server/src/api/handlers/error.rs
+++ b/server/src/api/handlers/error.rs
@@ -256,6 +256,7 @@ impl SetUnitHandlerError {
             Self::Service(SetUnitError::NotFound) => "not_found",
             Self::Service(SetUnitError::Forbidden(_)) => "forbidden",
             Self::Service(SetUnitError::InvalidRequest(_)) => "invalid_request",
+            Self::Service(SetUnitError::PhaseConflict) => "phase_conflict",
             Self::Service(SetUnitError::Repository(_)) => "repository_error",
         }
     }
@@ -308,6 +309,7 @@ impl SetTerritoryHandlerError {
             Self::Service(SetTerritoryError::WaterProvince) => "not_found",
             Self::Service(SetTerritoryError::Forbidden(_)) => "forbidden",
             Self::Service(SetTerritoryError::InvalidRequest(_)) => "invalid_request",
+            Self::Service(SetTerritoryError::PhaseConflict) => "phase_conflict",
             Self::Service(SetTerritoryError::Repository(_)) => "repository_error",
         }
     }

--- a/server/src/api/handlers/game_handler.rs
+++ b/server/src/api/handlers/game_handler.rs
@@ -647,7 +647,7 @@ where
             game_uuid: request.game_uuid,
             location: request.location.clone(),
             unit: unit_spec,
-            season: request.season,
+            season: request.season.to_lowercase(),
         })
         .map_err(SetUnitHandlerError::Service)?;
 
@@ -816,7 +816,7 @@ where
             game_uuid: request.game_uuid,
             code: request.code.clone(),
             power: request.power,
-            season: request.season,
+            season: request.season.to_lowercase(),
         })
         .map_err(SetTerritoryHandlerError::Service)?;
 
@@ -1988,5 +1988,91 @@ mod tests {
         .expect_err("should fail with wrong season");
 
         assert_eq!(error.code(), "phase_conflict");
+    }
+
+    #[test]
+    fn handle_set_unit_rejects_invalid_season_format() {
+        let user_repository = InMemoryUserRepository::new(vec![]);
+        let game_repository = InMemoryGameRepository::new();
+        let service = GameService::new(user_repository, game_repository);
+        let message_repository = new_test_message_repository();
+
+        for bad_season in &["", "1901", "1901x", "190s", "19011s", "SPRING"] {
+            let error = handle_set_unit(
+                &service,
+                &message_repository,
+                SetUnitRequest {
+                    authorization: "Bearer dummy".to_string(),
+                    game_uuid: uuid::Uuid::now_v7(),
+                    unit: None,
+                    location: "par".to_string(),
+                    season: bad_season.to_string(),
+                },
+            )
+            .expect_err(&format!("should reject invalid season: {bad_season}"));
+
+            assert_eq!(error.code(), "invalid_request", "season={bad_season}");
+        }
+    }
+
+    #[test]
+    fn handle_set_unit_accepts_uppercase_season() {
+        let owner_uuid = uuid::Uuid::now_v7();
+        let user_repository = InMemoryUserRepository::new(vec![UserRecord {
+            id: 1,
+            uuid: owner_uuid,
+            discord_user_id: "discord-owner".to_string(),
+            username: "owner".to_string(),
+            global_name: None,
+            avatar_hash: None,
+            avatar_url: None,
+            access_token: "token-owner".to_string(),
+            last_access_at: Utc::now(),
+        }]);
+        let game = sample_in_progress_game_for_handler(owner_uuid);
+        let game_uuid = game.uuid;
+        let game_repository = InMemoryGameRepository::new_with_games(vec![game]);
+        let service = GameService::new(user_repository, game_repository);
+        let message_repository = new_test_message_repository();
+
+        // "1901S" (大文字) は "1901s" に正規化されてフェイズと一致する
+        let result = handle_set_unit(
+            &service,
+            &message_repository,
+            SetUnitRequest {
+                authorization: "Bearer token-owner".to_string(),
+                game_uuid,
+                unit: None,
+                location: "par".to_string(),
+                season: "1901S".to_string(),
+            },
+        );
+
+        assert!(result.is_ok(), "uppercase season should be accepted");
+    }
+
+    #[test]
+    fn handle_set_territory_rejects_invalid_season_format() {
+        let user_repository = InMemoryUserRepository::new(vec![]);
+        let game_repository = InMemoryGameRepository::new();
+        let service = GameService::new(user_repository, game_repository);
+        let message_repository = new_test_message_repository();
+
+        for bad_season in &["", "1901", "1901x", "190f", "19011f", "FALL"] {
+            let error = handle_set_territory(
+                &service,
+                &message_repository,
+                SetTerritoryRequest {
+                    authorization: "Bearer dummy".to_string(),
+                    game_uuid: uuid::Uuid::now_v7(),
+                    code: "par".to_string(),
+                    power: None,
+                    season: bad_season.to_string(),
+                },
+            )
+            .expect_err(&format!("should reject invalid season: {bad_season}"));
+
+            assert_eq!(error.code(), "invalid_request", "season={bad_season}");
+        }
     }
 }

--- a/server/src/api/handlers/game_handler.rs
+++ b/server/src/api/handlers/game_handler.rs
@@ -4,6 +4,7 @@
 
 use axum::extract::Json;
 use axum::extract::Path;
+use axum::extract::Query;
 use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::http::StatusCode;
@@ -20,6 +21,8 @@ use super::CreateGameRequest;
 use super::CreateGameRequestBody;
 use super::CreateGameRequestValidationError;
 use super::CreateGameResponse;
+use super::DeleteTerritoryQueryParams;
+use super::DeleteUnitQueryParams;
 use super::DiscordIdentityProvider;
 use super::GameRepository;
 use super::GameService;
@@ -528,7 +531,7 @@ where
     G: GameRepository + Send + Sync + 'static,
     D: DiscordIdentityProvider + Send + Sync + 'static,
 {
-    dispatch_set_unit(state, game_uuid_str, location, headers, Some(body.unit)).await
+    dispatch_set_unit(state, game_uuid_str, location, headers, Some(body.unit), body.season).await
 }
 
 ///
@@ -538,13 +541,14 @@ pub(crate) async fn delete_admin_games_units<U, G, D>(
     State(state): State<AppState<U, G, D>>,
     Path((game_uuid_str, location)): Path<(String, String)>,
     headers: HeaderMap,
+    Query(params): Query<DeleteUnitQueryParams>,
 ) -> impl IntoResponse
 where
     U: UserRepository + Send + Sync + 'static,
     G: GameRepository + Send + Sync + 'static,
     D: DiscordIdentityProvider + Send + Sync + 'static,
 {
-    dispatch_set_unit(state, game_uuid_str, location, headers, None).await
+    dispatch_set_unit(state, game_uuid_str, location, headers, None, params.season).await
 }
 
 async fn dispatch_set_unit<U, G, D>(
@@ -553,6 +557,7 @@ async fn dispatch_set_unit<U, G, D>(
     location: String,
     headers: HeaderMap,
     unit: Option<UnitSpecBody>,
+    season: String,
 ) -> Response
 where
     U: UserRepository + Send + Sync + 'static,
@@ -581,6 +586,7 @@ where
         game_uuid,
         unit,
         location,
+        season,
     };
 
     let state_clone = state.clone();
@@ -601,6 +607,7 @@ where
                     SetUnitHandlerError::Service(SetUnitError::NotFound) => StatusCode::NOT_FOUND,
                     SetUnitHandlerError::Service(SetUnitError::Forbidden(_)) => StatusCode::FORBIDDEN,
                     SetUnitHandlerError::Service(SetUnitError::InvalidRequest(_)) => StatusCode::BAD_REQUEST,
+                    SetUnitHandlerError::Service(SetUnitError::PhaseConflict) => StatusCode::CONFLICT,
                     _ => StatusCode::INTERNAL_SERVER_ERROR,
                 };
                 (status, Json(error.to_api_error_response())).into_response()
@@ -640,6 +647,7 @@ where
             game_uuid: request.game_uuid,
             location: request.location.clone(),
             unit: unit_spec,
+            season: request.season,
         })
         .map_err(SetUnitHandlerError::Service)?;
 
@@ -693,7 +701,7 @@ where
     G: GameRepository + Send + Sync + 'static,
     D: DiscordIdentityProvider + Send + Sync + 'static,
 {
-    dispatch_set_territory(state, game_uuid_str, code, headers, Some(body.power)).await
+    dispatch_set_territory(state, game_uuid_str, code, headers, Some(body.power), body.season).await
 }
 
 ///
@@ -703,13 +711,14 @@ pub(crate) async fn delete_admin_games_territories<U, G, D>(
     State(state): State<AppState<U, G, D>>,
     Path((game_uuid_str, code)): Path<(String, String)>,
     headers: HeaderMap,
+    Query(params): Query<DeleteTerritoryQueryParams>,
 ) -> impl IntoResponse
 where
     U: UserRepository + Send + Sync + 'static,
     G: GameRepository + Send + Sync + 'static,
     D: DiscordIdentityProvider + Send + Sync + 'static,
 {
-    dispatch_set_territory(state, game_uuid_str, code, headers, None).await
+    dispatch_set_territory(state, game_uuid_str, code, headers, None, params.season).await
 }
 
 async fn dispatch_set_territory<U, G, D>(
@@ -718,6 +727,7 @@ async fn dispatch_set_territory<U, G, D>(
     code: String,
     headers: HeaderMap,
     power: Option<String>,
+    season: String,
 ) -> Response
 where
     U: UserRepository + Send + Sync + 'static,
@@ -749,6 +759,7 @@ where
         game_uuid,
         code,
         power,
+        season,
     };
 
     let state_clone = state.clone();
@@ -770,6 +781,7 @@ where
                     SetTerritoryHandlerError::Service(SetTerritoryError::WaterProvince) => StatusCode::NOT_FOUND,
                     SetTerritoryHandlerError::Service(SetTerritoryError::Forbidden(_)) => StatusCode::FORBIDDEN,
                     SetTerritoryHandlerError::Service(SetTerritoryError::InvalidRequest(_)) => StatusCode::BAD_REQUEST,
+                    SetTerritoryHandlerError::Service(SetTerritoryError::PhaseConflict) => StatusCode::CONFLICT,
                     _ => StatusCode::INTERNAL_SERVER_ERROR,
                 };
                 (status, Json(error.to_api_error_response())).into_response()
@@ -804,6 +816,7 @@ where
             game_uuid: request.game_uuid,
             code: request.code.clone(),
             power: request.power,
+            season: request.season,
         })
         .map_err(SetTerritoryHandlerError::Service)?;
 
@@ -1546,6 +1559,7 @@ mod tests {
                 game_uuid: uuid::Uuid::now_v7(),
                 unit: None,
                 location: "par".to_string(),
+                season: "1901s".to_string(),
             },
         )
         .expect_err("should fail without authorization");
@@ -1586,6 +1600,7 @@ mod tests {
                     kind: "a".to_string(),
                 }),
                 location: "par".to_string(),
+                season: "1901s".to_string(),
             },
         );
 
@@ -1624,6 +1639,7 @@ mod tests {
                     kind: "a".to_string(),
                 }),
                 location: "par".to_string(),
+                season: "1901s".to_string(),
             },
         )
         .expect("should succeed");
@@ -1666,6 +1682,7 @@ mod tests {
                 game_uuid,
                 unit: None,
                 location: "par".to_string(),
+                season: "1901s".to_string(),
             },
         )
         .expect("should succeed");
@@ -1690,6 +1707,7 @@ mod tests {
                 game_uuid: uuid::Uuid::now_v7(),
                 code: "par".to_string(),
                 power: Some("f".to_string()),
+                season: "1901s".to_string(),
             },
         )
         .expect_err("should fail without authorization");
@@ -1725,6 +1743,7 @@ mod tests {
                 game_uuid,
                 code: "par".to_string(),
                 power: Some("f".to_string()),
+                season: "1901s".to_string(),
             },
         )
         .expect("should succeed");
@@ -1768,6 +1787,7 @@ mod tests {
                 game_uuid,
                 code: "par".to_string(),
                 power: Some("e".to_string()), // France → England に変更
+                season: "1901s".to_string(),
             },
         )
         .expect("should succeed");
@@ -1809,6 +1829,7 @@ mod tests {
                 game_uuid,
                 code: "par".to_string(),
                 power: None, // DELETE: 保有解除
+                season: "1901s".to_string(),
             },
         )
         .expect("should succeed");
@@ -1850,6 +1871,7 @@ mod tests {
                 game_uuid,
                 code: "par".to_string(),
                 power: Some("f".to_string()), // France → France（変更なし）
+                season: "1901s".to_string(),
             },
         )
         .expect("should succeed");
@@ -1888,10 +1910,83 @@ mod tests {
                 game_uuid,
                 code: "nth".to_string(), // North Sea = 海洋プロヴィンス
                 power: Some("f".to_string()),
+                season: "1901s".to_string(),
             },
         )
         .expect_err("water province should be rejected");
 
         assert_eq!(error.code(), "not_found");
+    }
+
+    #[test]
+    fn handle_set_unit_rejects_wrong_season() {
+        let owner_uuid = uuid::Uuid::now_v7();
+        let user_repository = InMemoryUserRepository::new(vec![UserRecord {
+            id: 1,
+            uuid: owner_uuid,
+            discord_user_id: "discord-owner".to_string(),
+            username: "owner".to_string(),
+            global_name: None,
+            avatar_hash: None,
+            avatar_url: None,
+            access_token: "token-owner".to_string(),
+            last_access_at: Utc::now(),
+        }]);
+        let game = sample_in_progress_game_for_handler(owner_uuid);
+        let game_uuid = game.uuid;
+        let game_repository = InMemoryGameRepository::new_with_games(vec![game]);
+        let service = GameService::new(user_repository, game_repository);
+        let message_repository = new_test_message_repository();
+
+        let error = handle_set_unit(
+            &service,
+            &message_repository,
+            SetUnitRequest {
+                authorization: "Bearer token-owner".to_string(),
+                game_uuid,
+                unit: None,
+                location: "par".to_string(),
+                season: "1901f".to_string(), // wrong season (game is 1901s)
+            },
+        )
+        .expect_err("should fail with wrong season");
+
+        assert_eq!(error.code(), "phase_conflict");
+    }
+
+    #[test]
+    fn handle_set_territory_rejects_wrong_season() {
+        let owner_uuid = uuid::Uuid::now_v7();
+        let user_repository = InMemoryUserRepository::new(vec![UserRecord {
+            id: 1,
+            uuid: owner_uuid,
+            discord_user_id: "discord-owner".to_string(),
+            username: "owner".to_string(),
+            global_name: None,
+            avatar_hash: None,
+            avatar_url: None,
+            access_token: "token-owner".to_string(),
+            last_access_at: Utc::now(),
+        }]);
+        let game = sample_in_progress_game_for_handler(owner_uuid);
+        let game_uuid = game.uuid;
+        let game_repository = InMemoryGameRepository::new_with_games(vec![game]);
+        let service = GameService::new(user_repository, game_repository);
+        let message_repository = new_test_message_repository();
+
+        let error = handle_set_territory(
+            &service,
+            &message_repository,
+            SetTerritoryRequest {
+                authorization: "Bearer token-owner".to_string(),
+                game_uuid,
+                code: "par".to_string(),
+                power: Some("f".to_string()),
+                season: "1901f".to_string(), // wrong season (game is 1901s)
+            },
+        )
+        .expect_err("should fail with wrong season");
+
+        assert_eq!(error.code(), "phase_conflict");
     }
 }

--- a/server/src/api/requests.rs
+++ b/server/src/api/requests.rs
@@ -19,6 +19,8 @@ pub(crate) use error::SetTerritoryRequestValidationError;
 pub(crate) use error::SetUnitRequestValidationError;
 pub(crate) use game_request::CreateGameRequest;
 pub(crate) use game_request::CreateGameRequestBody;
+pub(crate) use game_request::DeleteTerritoryQueryParams;
+pub(crate) use game_request::DeleteUnitQueryParams;
 pub(crate) use game_request::JoinGameRequest;
 pub(crate) use game_request::JoinGameRequestBody;
 pub(crate) use game_request::SetDrawProposalRequest;
@@ -27,8 +29,6 @@ pub(crate) use game_request::SetTerritoryRequest;
 pub(crate) use game_request::SetTerritoryRequestBody;
 pub(crate) use game_request::SetUnitRequest;
 pub(crate) use game_request::SetUnitRequestBody;
-pub(crate) use game_request::DeleteUnitQueryParams;
-pub(crate) use game_request::DeleteTerritoryQueryParams;
 // テストコード (game_handler.rs) からのみ参照されるため unused_imports 警告を抑制する
 #[allow(unused_imports)]
 pub(crate) use game_request::UnitSpecBody;

--- a/server/src/api/requests.rs
+++ b/server/src/api/requests.rs
@@ -27,6 +27,8 @@ pub(crate) use game_request::SetTerritoryRequest;
 pub(crate) use game_request::SetTerritoryRequestBody;
 pub(crate) use game_request::SetUnitRequest;
 pub(crate) use game_request::SetUnitRequestBody;
+pub(crate) use game_request::DeleteUnitQueryParams;
+pub(crate) use game_request::DeleteTerritoryQueryParams;
 // テストコード (game_handler.rs) からのみ参照されるため unused_imports 警告を抑制する
 #[allow(unused_imports)]
 pub(crate) use game_request::UnitSpecBody;

--- a/server/src/api/requests/error.rs
+++ b/server/src/api/requests/error.rs
@@ -59,6 +59,7 @@ pub(crate) enum SetUnitRequestValidationError {
     InvalidAuthorizationScheme,
     MissingAccessToken,
     InvalidGameUuid,
+    InvalidSeason,
 }
 
 ///
@@ -70,4 +71,5 @@ pub(crate) enum SetTerritoryRequestValidationError {
     InvalidAuthorizationScheme,
     MissingAccessToken,
     InvalidGameUuid,
+    InvalidSeason,
 }

--- a/server/src/api/requests/game_request.rs
+++ b/server/src/api/requests/game_request.rs
@@ -157,6 +157,7 @@ pub(crate) struct UnitSpecBody {
 #[derive(Debug, Deserialize)]
 pub(crate) struct SetUnitRequestBody {
     pub unit: UnitSpecBody,
+    pub season: String,
 }
 
 ///
@@ -168,6 +169,7 @@ pub(crate) struct SetUnitRequest {
     pub game_uuid: Uuid,
     pub unit: Option<UnitSpecBody>,
     pub location: String,
+    pub season: String,
 }
 
 /// ユニット配置制御リクエストの構造体の実装
@@ -196,6 +198,7 @@ impl SetUnitRequest {
 #[derive(Debug, Deserialize)]
 pub(crate) struct SetTerritoryRequestBody {
     pub power: String,
+    pub season: String,
 }
 
 ///
@@ -207,6 +210,7 @@ pub(crate) struct SetTerritoryRequest {
     pub game_uuid: Uuid,
     pub code: String,
     pub power: Option<String>,
+    pub season: String,
 }
 
 /// 占領情報編集リクエストの構造体の実装
@@ -227,4 +231,20 @@ impl SetTerritoryRequest {
 
         Ok(())
     }
+}
+
+///
+/// ユニット削除リクエストのクエリパラメータ構造体
+///
+#[derive(Debug, Deserialize)]
+pub(crate) struct DeleteUnitQueryParams {
+    pub season: String,
+}
+
+///
+/// 占領情報削除リクエストのクエリパラメータ構造体
+///
+#[derive(Debug, Deserialize)]
+pub(crate) struct DeleteTerritoryQueryParams {
+    pub season: String,
 }

--- a/server/src/api/requests/game_request.rs
+++ b/server/src/api/requests/game_request.rs
@@ -188,13 +188,14 @@ impl SetUnitRequest {
             return Err(SetUnitRequestValidationError::MissingAccessToken);
         }
 
+        if !is_valid_season(&self.season) {
+            return Err(SetUnitRequestValidationError::InvalidSeason);
+        }
+
         Ok(())
     }
 }
 
-///
-/// 占領情報編集リクエストパラメータボディ構造体（PUT のみ使用）
-///
 #[derive(Debug, Deserialize)]
 pub(crate) struct SetTerritoryRequestBody {
     pub power: String,
@@ -229,13 +230,14 @@ impl SetTerritoryRequest {
             return Err(SetTerritoryRequestValidationError::MissingAccessToken);
         }
 
+        if !is_valid_season(&self.season) {
+            return Err(SetTerritoryRequestValidationError::InvalidSeason);
+        }
+
         Ok(())
     }
 }
 
-///
-/// ユニット削除リクエストのクエリパラメータ構造体
-///
 #[derive(Debug, Deserialize)]
 pub(crate) struct DeleteUnitQueryParams {
     pub season: String,
@@ -247,4 +249,13 @@ pub(crate) struct DeleteUnitQueryParams {
 #[derive(Debug, Deserialize)]
 pub(crate) struct DeleteTerritoryQueryParams {
     pub season: String,
+}
+
+/// season 文字列が有効な形式かどうかを検証する（例: "1901s", "1901F"）
+fn is_valid_season(season: &str) -> bool {
+    let bytes = season.as_bytes();
+    if bytes.len() != 5 {
+        return false;
+    }
+    bytes[..4].iter().all(|b| b.is_ascii_digit()) && matches!(bytes[4], b's' | b'S' | b'f' | b'F')
 }

--- a/server/src/domain/models/message.rs
+++ b/server/src/domain/models/message.rs
@@ -81,23 +81,48 @@ pub(crate) struct SystemNotice {}
 ///
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum SystemNoticeCatalog {
-    GameCreated { user: User },
-    PlayerJoined { user: User },
+    GameCreated {
+        user: User,
+    },
+    PlayerJoined {
+        user: User,
+    },
     Ready,
     Aborted,
-    StartSeason { season: String },
+    StartSeason {
+        season: String,
+    },
     DrawProposed,
     OwnerAbsent,
     DrawRescinded,
-    Solo { power: Power },
+    Solo {
+        power: Power,
+    },
     Draw,
     Closed,
-    UnitPlaced { unit: Unit },
-    UnitReplaced { old_unit: Unit, new_unit: Unit },
-    UnitRemoved { unit: Unit },
-    TerritorySet { province: Province, power: Power },
-    TerritoryReplaced { province: Province, old_power: Power, new_power: Power },
-    TerritoryReleased { province: Province, old_power: Power },
+    UnitPlaced {
+        unit: Unit,
+    },
+    UnitReplaced {
+        old_unit: Unit,
+        new_unit: Unit,
+    },
+    UnitRemoved {
+        unit: Unit,
+    },
+    TerritorySet {
+        province: Province,
+        power: Power,
+    },
+    TerritoryReplaced {
+        province: Province,
+        old_power: Power,
+        new_power: Power,
+    },
+    TerritoryReleased {
+        province: Province,
+        old_power: Power,
+    },
 }
 
 /// システムメッセージ定義の列挙体の fmt::Display トレイト実装
@@ -170,7 +195,12 @@ impl fmt::Display for SystemNoticeCatalog {
                 )
             }
             Self::TerritoryReleased { province, old_power } => {
-                write!(f, "{} が保有していた {} が解放されました。", old_power.name(), province.jname())
+                write!(
+                    f,
+                    "{} が保有していた {} が解放されました。",
+                    old_power.name(),
+                    province.jname()
+                )
             }
         }
     }

--- a/server/src/services/error.rs
+++ b/server/src/services/error.rs
@@ -148,6 +148,7 @@ pub(crate) enum SetUnitError {
     NotFound,
     Forbidden(String),
     InvalidRequest(String),
+    PhaseConflict,
     Repository(RepositoryError),
 }
 
@@ -162,6 +163,7 @@ impl fmt::Display for SetUnitError {
             Self::NotFound => write!(f, "game not found"),
             Self::Forbidden(message) => write!(f, "forbidden: {}", message),
             Self::InvalidRequest(message) => write!(f, "invalid request: {}", message),
+            Self::PhaseConflict => write!(f, "phase has changed since this request was issued"),
             Self::Repository(error) => write!(f, "repository error: {}", error),
         }
     }
@@ -197,6 +199,7 @@ pub(crate) enum SetTerritoryError {
     WaterProvince,
     Forbidden(String),
     InvalidRequest(String),
+    PhaseConflict,
     Repository(RepositoryError),
 }
 
@@ -212,6 +215,7 @@ impl fmt::Display for SetTerritoryError {
             Self::WaterProvince => write!(f, "cannot set territory ownership for a water province"),
             Self::Forbidden(message) => write!(f, "forbidden: {}", message),
             Self::InvalidRequest(message) => write!(f, "invalid request: {}", message),
+            Self::PhaseConflict => write!(f, "phase has changed since this request was issued"),
             Self::Repository(error) => write!(f, "repository error: {}", error),
         }
     }

--- a/server/src/services/game_service.rs
+++ b/server/src/services/game_service.rs
@@ -110,6 +110,7 @@ pub(crate) struct SetUnitCommand {
     pub game_uuid: Uuid,
     pub location: String,
     pub unit: Option<UnitSpec>,
+    pub season: String,
 }
 
 ///
@@ -132,6 +133,7 @@ pub(crate) struct SetTerritoryCommand {
     pub game_uuid: Uuid,
     pub code: String,
     pub power: Option<String>,
+    pub season: String,
 }
 
 ///
@@ -490,6 +492,10 @@ where
             ));
         }
 
+        if game.current_turn() != command.season {
+            return Err(SetUnitError::PhaseConflict);
+        }
+
         let location = Province::from_code(&command.location)
             .ok_or_else(|| SetUnitError::InvalidRequest(format!("invalid location: {}", command.location)))?;
 
@@ -626,6 +632,10 @@ where
             return Err(SetTerritoryError::Forbidden(
                 "territories can only be set during a main phase".to_string(),
             ));
+        }
+
+        if game.current_turn() != command.season {
+            return Err(SetTerritoryError::PhaseConflict);
         }
 
         let province = Province::from_code(&command.code)
@@ -1901,6 +1911,7 @@ mod tests {
                 game_uuid,
                 location: "par".to_string(),
                 unit: None,
+                season: "1901s".to_string(),
             })
             .expect_err("should reject empty token");
 
@@ -1922,6 +1933,7 @@ mod tests {
                 game_uuid,
                 location: "par".to_string(),
                 unit: None,
+                season: "1901s".to_string(),
             })
             .expect_err("should reject unknown token");
 
@@ -1941,6 +1953,7 @@ mod tests {
                 game_uuid: Uuid::now_v7(),
                 location: "par".to_string(),
                 unit: None,
+                season: "1901s".to_string(),
             })
             .expect_err("should reject when game not found");
 
@@ -1976,6 +1989,7 @@ mod tests {
                 game_uuid,
                 location: "par".to_string(),
                 unit: None,
+                season: "1901s".to_string(),
             })
             .expect_err("should reject non-owner");
 
@@ -1997,6 +2011,7 @@ mod tests {
                 game_uuid,
                 location: "par".to_string(),
                 unit: None,
+                season: "1901s".to_string(),
             })
             .expect_err("should reject when not main phase");
 
@@ -2021,6 +2036,7 @@ mod tests {
                     power_symbol: "f".to_string(),
                     kind_str: "a".to_string(),
                 }),
+                season: "1901s".to_string(),
             })
             .expect_err("should reject invalid location");
 
@@ -2046,6 +2062,7 @@ mod tests {
                     power_symbol: "f".to_string(),
                     kind_str: "a".to_string(),
                 }),
+                season: "1901s".to_string(),
             })
             .expect_err("should reject army in sea province");
 
@@ -2071,6 +2088,7 @@ mod tests {
                     power_symbol: "f".to_string(),
                     kind_str: "f".to_string(),
                 }),
+                season: "1901s".to_string(),
             })
             .expect_err("should reject fleet in inland province");
 
@@ -2096,6 +2114,7 @@ mod tests {
                     power_symbol: "f".to_string(),
                     kind_str: "f".to_string(),
                 }),
+                season: "1901s".to_string(),
             })
             .expect_err("should reject fleet on dual-coast base code");
 
@@ -2121,6 +2140,7 @@ mod tests {
                     power_symbol: "f".to_string(),
                     kind_str: "a".to_string(),
                 }),
+                season: "1901s".to_string(),
             })
             .expect("should succeed");
 
@@ -2168,6 +2188,7 @@ mod tests {
                     power_symbol: "f".to_string(),
                     kind_str: "a".to_string(),
                 }),
+                season: "1901s".to_string(),
             })
             .expect("should succeed");
 
@@ -2199,6 +2220,7 @@ mod tests {
                 game_uuid,
                 location: "par".to_string(),
                 unit: None,
+                season: "1901s".to_string(),
             })
             .expect("should succeed");
 
@@ -2240,6 +2262,7 @@ mod tests {
                     power_symbol: "f".to_string(),
                     kind_str: "f".to_string(),
                 }),
+                season: "1901s".to_string(),
             })
             .expect("should succeed");
 
@@ -2258,5 +2281,27 @@ mod tests {
 
         assert!(result.old_unit.is_some(), "old_unit should be Some");
         assert!(result.new_unit.is_some(), "new_unit should be Some");
+    }
+
+    #[test]
+    fn set_unit_rejects_wrong_season() {
+        let owner_uuid = Uuid::now_v7();
+        let user_repository = InMemoryUserRepository::new(vec![owner_user_record(owner_uuid)]);
+        let game = sample_in_progress_game(owner_uuid);
+        let game_uuid = game.uuid;
+        let game_repository = InMemoryGameRepository::new(vec![game]);
+        let service = GameService::new(user_repository, game_repository);
+
+        let error = service
+            .set_unit(SetUnitCommand {
+                access_token: "token-owner".to_string(),
+                game_uuid,
+                location: "par".to_string(),
+                unit: None,
+                season: "1901f".to_string(), // wrong season (game is 1901s)
+            })
+            .expect_err("should reject mismatched season");
+
+        assert!(matches!(error, SetUnitError::PhaseConflict));
     }
 }


### PR DESCRIPTION
管理者向け編集API（PUT/DELETE /admin/games/:uuid/units/:location および PUT/DELETE /admin/games/:uuid/territories/:code）において、リクエスト発行時と 処理時でゲームフェイズが変わっていた場合に 409 Conflict を返す仕組みを追加した。

背景:
game_update_lock はミドルウェアでの進行処理後にドロップされるため、
別リクエストの進行処理がハンドラ実行前に割り込み、フェイズが進む可能性があった。
（例: SpringMain → FallMain へのスキップ）

変更内容:
- SetUnitError / SetTerritoryError に PhaseConflict バリアントを追加
- SetUnitCommand / SetTerritoryCommand に season フィールドを追加
- set_unit() / set_territory() で game.current_turn() != season の場合に PhaseConflict を返す
- PUT リクエストボディ（JSON）に season フィールドを追加
- DELETE リクエスト用クエリパラメータ構造体 DeleteUnitQueryParams / DeleteTerritoryQueryParams を新規追加し、?season= で受け取る
- PhaseConflict → HTTP 409 のマッピングをハンドラに追加
- 各エラーの code() に "phase_conflict" を追加
- PhaseConflict シナリオのテストを追加（service 1件、handler 2件）